### PR TITLE
feat: complete phase 2 ingestion pipeline

### DIFF
--- a/PHASE_2_SUMMARY.md
+++ b/PHASE_2_SUMMARY.md
@@ -1,0 +1,64 @@
+# Phase Summary: Phase 2 – Chunking & Embeddings
+
+**Date:** 2025-10-08  
+**Agent:** Cascade (Builder)  
+**Duration:** 2 days (Oct 7 – Oct 8)
+
+---
+
+## 📋 Overview
+
+Completed the semantic processing pipeline by implementing chunking, embedding integration, storage, and orchestration, culminating in a successful ingestion of the 20 MB PDF through `/api/ingest`. All unit suites and a manual end-to-end run confirm readiness for Phase 3.
+
+---
+
+## ✅ Features Implemented
+
+- [x] **Chunking Engine:** `apps/server/src/pipeline/chunk.ts`
+- [x] **Embedding Client:** `apps/server/src/pipeline/embed.ts`
+- [x] **Storage Layer:** `apps/server/src/pipeline/store.ts`
+- [x] **Ingestion Orchestrator & Route Integration:** `apps/server/src/pipeline/orchestrator.ts`, `apps/server/src/routes/ingest.ts`
+- [x] **Unit Tests:** `apps/server/src/pipeline/__tests__/chunk.test.ts`, `apps/server/src/pipeline/__tests__/embed.test.ts`, `apps/server/src/pipeline/__tests__/orchestrator.test.ts`
+- [x] **Manual Ingest Validation:** `/api/ingest` → `status: complete` for `20MB-TESTFILE.ORG.pdf`
+
+---
+
+## 📁 Files Changed
+
+- `apps/server/src/pipeline/chunk.ts`
+- `apps/server/src/pipeline/embed.ts`
+- `apps/server/src/pipeline/store.ts`
+- `apps/server/src/pipeline/orchestrator.ts`
+- `apps/server/src/routes/ingest.ts`
+- `apps/server/src/pipeline/__tests__/chunk.test.ts`
+- `apps/server/src/pipeline/__tests__/embed.test.ts`
+- `apps/server/src/pipeline/__tests__/orchestrator.test.ts`
+
+---
+
+## 🧪 Tests
+
+- `pnpm --filter @synthesis/server test`
+- Manual ingest via `curl -F "collection_id=c8d16e8a-a076-47dc-89f8-de126ceba9bf" -F "files=@/home/kngpnn/dev/synthesis/20MB-TESTFILE.ORG.pdf" http://localhost:3333/api/ingest` → document `status: complete`, chunks persisted.
+
+---
+
+## ✅ Acceptance Criteria
+
+- [x] Chunking respects sentence & paragraph boundaries (`apps/server/src/pipeline/chunk.ts`)
+- [x] Ollama embedding integration with retries (`apps/server/src/pipeline/embed.ts`)
+- [x] Chunks + embeddings stored in DB (`apps/server/src/pipeline/store.ts`)
+- [x] `/api/ingest` orchestrates extract → chunk → embed → store (`apps/server/src/pipeline/orchestrator.ts`)
+- [x] Manual large-file ingestion succeeds end-to-end
+
+---
+
+## ⚠️ Outstanding Work
+
+- Document the manual ingest results in project docs.
+- Optional: add SQL query or endpoint to inspect chunk counts quickly.
+- Future improvement: optimize `storeChunks()` batching/transactions to reduce round-trips for large documents.
+
+---
+
+Phase 2 is complete and the ingestion pipeline is production-ready; Phase 3 (search & agent tooling) can begin.

--- a/apps/server/src/pipeline/__tests__/chunk.test.ts
+++ b/apps/server/src/pipeline/__tests__/chunk.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { chunkText } from '../chunk.js';
+
+function buildLongString(char: string, length: number): string {
+  return Array.from({ length }, () => char).join('');
+}
+
+describe('chunkText', () => {
+  it('returns empty array for empty input', () => {
+    expect(chunkText('   ')).toEqual([]);
+  });
+
+  it('produces chunks within max size and with configured overlap', () => {
+    const text = buildLongString('a', 2000);
+    const chunks = chunkText(text);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.text.length).toBeLessThanOrEqual(800);
+    }
+
+    for (let i = 0; i < chunks.length - 1; i += 1) {
+      const current = chunks[i];
+      const next = chunks[i + 1];
+      expect(current.text.slice(-150)).toEqual(next.text.slice(0, 150));
+      expect(next.metadata.startOffset).toBeGreaterThanOrEqual(current.metadata.startOffset);
+      expect(next.metadata.endOffset).toBeGreaterThan(next.metadata.startOffset);
+    }
+  });
+
+  it('keeps paragraphs together until the max size is reached, then splits at boundary', () => {
+    const paragraphs = [
+      'First paragraph contains insight but remains relatively short.',
+      'Second paragraph continues the discussion and ideally stays with the first paragraph when possible.',
+      'Third paragraph introduces additional detail and is long enough that it should begin a new chunk once the limit is reached.',
+    ];
+    const text = paragraphs.join('\n\n');
+
+    const chunks = chunkText(text, { maxSize: 260, overlap: 30 });
+
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    expect(chunks[0].text).toContain(paragraphs[0]);
+    expect(chunks[0].text).toContain(paragraphs[1]);
+    expect(chunks[0].text).not.toContain(paragraphs[2]);
+
+    const remainderText = chunks
+      .slice(1)
+      .map((chunk) => chunk.text)
+      .join(' ');
+    expect(remainderText).toContain(paragraphs[2].slice(0, 30));
+
+    const overlap = chunks[0].metadata.endOffset - chunks[1].metadata.startOffset;
+    expect(overlap).toBeGreaterThanOrEqual(0);
+    expect(overlap).toBeLessThanOrEqual(35);
+  });
+
+  it('extracts heading metadata when applicable', () => {
+    const text = ['Introduction', '', 'This section contains important details.'].join('\n');
+    const [firstChunk] = chunkText(text, { maxSize: 120, overlap: 20 });
+
+    expect(firstChunk.metadata.heading).toBe('Introduction');
+    expect(firstChunk.metadata.startOffset).toBe(0);
+    expect(firstChunk.metadata.endOffset).toBeGreaterThan(firstChunk.metadata.startOffset);
+  });
+
+  it('throws when overlap is invalid', () => {
+    expect(() => chunkText('content', { maxSize: 150, overlap: 200 })).toThrow(
+      /overlap must be smaller than maxSize/
+    );
+    expect(() => chunkText('content', { maxSize: 0 })).toThrow(/greater than zero/);
+    expect(() => chunkText('content', { overlap: -1 })).toThrow(/cannot be negative/);
+  });
+
+  it('handles extremely long paragraphs by splitting on sentence boundaries', () => {
+    const paragraph = `${buildLongString('a', 750)}. ${buildLongString('b', 600)}.`;
+    const chunks = chunkText(paragraph, { maxSize: 400, overlap: 50 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.text.length).toBeLessThanOrEqual(450);
+    }
+
+    const boundaryIndex = chunks.findIndex((chunk) => chunk.text.trimEnd().endsWith('.'));
+    expect(boundaryIndex).toBeGreaterThanOrEqual(0);
+
+    const boundaryChunk = chunks[boundaryIndex];
+    const followingChunk = chunks[boundaryIndex + 1];
+    expect(followingChunk).toBeDefined();
+    if (!followingChunk) {
+      throw new Error('Expected subsequent chunk when validating sentence boundary split');
+    }
+
+    expect(followingChunk.text.trimStart().startsWith('b'.repeat(5))).toBe(true);
+    const overlap = boundaryChunk.metadata.endOffset - followingChunk.metadata.startOffset;
+    expect(followingChunk.metadata.startOffset).toBeLessThanOrEqual(
+      boundaryChunk.metadata.endOffset
+    );
+    expect(overlap).toBeGreaterThanOrEqual(0);
+    expect(overlap).toBeLessThanOrEqual(50);
+  });
+});

--- a/apps/server/src/pipeline/__tests__/chunk.test.ts
+++ b/apps/server/src/pipeline/__tests__/chunk.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { chunkText } from '../chunk.js';
+
+function buildLongString(char: string, length: number): string {
+  return Array.from({ length }, () => char).join('');
+}
+
+describe('chunkText', () => {
+  it('returns empty array for empty input', () => {
+    expect(chunkText('   ')).toEqual([]);
+  });
+
+  it('produces chunks within max size and with configured overlap', () => {
+    const text = buildLongString('a', 2000);
+    const chunks = chunkText(text);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.text.length).toBeLessThanOrEqual(800);
+    }
+
+    for (let i = 0; i < chunks.length - 1; i += 1) {
+      const current = chunks[i];
+      const next = chunks[i + 1];
+      expect(current.text.slice(-150)).toEqual(next.text.slice(0, 150));
+      expect(next.metadata.startOffset).toBeGreaterThanOrEqual(current.metadata.startOffset);
+      expect(next.metadata.endOffset).toBeGreaterThan(next.metadata.startOffset);
+    }
+  });
+
+  it('keeps paragraphs together until the max size is reached, then splits at boundary', () => {
+    const paragraphs = [
+      'First paragraph contains insight but remains relatively short.',
+      'Second paragraph continues the discussion and ideally stays with the first paragraph when possible.',
+      'Third paragraph introduces additional detail and is long enough that it should begin a new chunk once the limit is reached.',
+    ];
+    const text = paragraphs.join('\n\n');
+
+    const chunks = chunkText(text, { maxSize: 260, overlap: 30 });
+
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    expect(chunks[0].text).toContain(paragraphs[0]);
+    expect(chunks[0].text).toContain(paragraphs[1]);
+    expect(chunks[0].text).not.toContain(paragraphs[2]);
+
+    const remainderText = chunks
+      .slice(1)
+      .map((chunk) => chunk.text)
+      .join(' ');
+    expect(remainderText).toContain(paragraphs[2].slice(0, 30));
+
+    const overlap = chunks[0].metadata.endOffset - chunks[1].metadata.startOffset;
+    expect(overlap).toBeGreaterThanOrEqual(0);
+    expect(overlap).toBeLessThanOrEqual(35);
+  });
+
+  it('extracts heading metadata when applicable', () => {
+    const text = ['Introduction', '', 'This section contains important details.'].join('\n');
+    const [firstChunk] = chunkText(text, { maxSize: 120, overlap: 20 });
+
+    expect(firstChunk.metadata.heading).toBe('Introduction');
+    expect(firstChunk.metadata.startOffset).toBe(0);
+    expect(firstChunk.metadata.endOffset).toBeGreaterThan(firstChunk.metadata.startOffset);
+  });
+
+  it('throws when overlap is invalid', () => {
+    expect(() => chunkText('content', { maxSize: 150, overlap: 200 })).toThrow(
+      /overlap must be smaller than maxSize/
+    );
+    expect(() => chunkText('content', { maxSize: 0 })).toThrow(/greater than zero/);
+    expect(() => chunkText('content', { overlap: -1 })).toThrow(/cannot be negative/);
+  });
+
+  it('handles extremely long paragraphs by splitting on sentence boundaries', () => {
+    const paragraph = `${buildLongString('a', 750)}. ${buildLongString('b', 600)}.`;
+    const chunks = chunkText(paragraph, { maxSize: 400, overlap: 50 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.text.length).toBeLessThanOrEqual(450);
+    }
+
+    const boundaryIndex = chunks.findIndex((chunk) => chunk.text.trimEnd().endsWith('.'));
+    expect(boundaryIndex).toBeGreaterThanOrEqual(0);
+
+    const boundaryChunk = chunks[boundaryIndex];
+    const followingChunk = chunks[boundaryIndex + 1];
+    expect(followingChunk).toBeDefined();
+    expect(followingChunk?.text.trimStart().startsWith('b'.repeat(5))).toBe(true);
+    expect(followingChunk?.metadata.startOffset).toBe(boundaryChunk.metadata.endOffset);
+  });
+});

--- a/apps/server/src/pipeline/__tests__/embed.test.ts
+++ b/apps/server/src/pipeline/__tests__/embed.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { __setOllamaClientForTesting, embedBatch, embedText } from '../embed.js';
+
+describe('embed pipeline', () => {
+  const mockEmbeddings = vi.fn();
+
+  beforeEach(() => {
+    mockEmbeddings.mockReset();
+    __setOllamaClientForTesting({
+      embeddings: mockEmbeddings,
+    });
+  });
+
+  afterEach(() => {
+    __setOllamaClientForTesting(null);
+  });
+
+  it('returns numeric vector from embedText', async () => {
+    mockEmbeddings.mockResolvedValue({ embedding: Array(768).fill(0.25) });
+
+    const vector = await embedText('hello world');
+
+    expect(vector).toHaveLength(768);
+    expect(vector.every((value) => typeof value === 'number')).toBe(true);
+    expect(mockEmbeddings).toHaveBeenCalledTimes(1);
+    expect(mockEmbeddings).toHaveBeenCalledWith({
+      model: 'nomic-embed-text',
+      prompt: 'hello world',
+    });
+  });
+
+  it('retries transient failures before succeeding', async () => {
+    mockEmbeddings
+      .mockRejectedValueOnce(new Error('network issue'))
+      .mockRejectedValueOnce(new Error('still failing'))
+      .mockResolvedValue({ embedding: Array(5).fill(1) });
+
+    const vector = await embedText('retry me', {
+      model: 'custom-model',
+      maxRetries: 3,
+      retryDelayMs: 0,
+    });
+
+    expect(vector).toEqual([1, 1, 1, 1, 1]);
+    expect(mockEmbeddings).toHaveBeenCalledTimes(3);
+  });
+
+  it('processes texts in batches with embedBatch', async () => {
+    mockEmbeddings.mockResolvedValue({ embedding: [0.1, 0.2, 0.3] });
+
+    const texts = ['one', 'two', 'three'];
+    const vectors = await embedBatch(texts, { batchSize: 2, retryDelayMs: 0 });
+
+    expect(vectors).toHaveLength(3);
+    expect(mockEmbeddings).toHaveBeenCalledTimes(3);
+    expect(vectors.every((vector) => vector.length === 3)).toBe(true);
+  });
+
+  it('throws when Ollama response is missing embedding array', async () => {
+    mockEmbeddings.mockResolvedValue({ embedding: undefined });
+
+    await expect(embedText('invalid response')).rejects.toThrow(/missing embedding array/);
+  });
+
+  it('throws when batchSize is invalid', async () => {
+    await expect(embedBatch(['a'], { batchSize: 0 })).rejects.toThrow(/greater than zero/);
+  });
+});

--- a/apps/server/src/pipeline/__tests__/orchestrator.test.ts
+++ b/apps/server/src/pipeline/__tests__/orchestrator.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const readFileMock = vi.fn<(path: string) => Promise<Buffer>>();
+
+const getDocumentMock = vi.fn();
+const updateDocumentStatusMock = vi.fn();
+const extractMock = vi.fn();
+const chunkTextMock = vi.fn();
+const embedBatchMock = vi.fn();
+const storeChunksMock = vi.fn();
+
+vi.mock('node:fs/promises', () => ({
+  __esModule: true,
+  default: {
+    readFile: readFileMock,
+  },
+  readFile: readFileMock,
+}));
+
+vi.mock('@synthesis/db', () => ({
+  __esModule: true,
+  getDocument: (...args: unknown[]) => getDocumentMock(...args),
+  updateDocumentStatus: (...args: unknown[]) => updateDocumentStatusMock(...args),
+}));
+
+vi.mock('../extract.js', () => ({
+  __esModule: true,
+  extract: (...args: unknown[]) => extractMock(...args),
+}));
+
+vi.mock('../chunk.js', () => ({
+  __esModule: true,
+  chunkText: (...args: unknown[]) => chunkTextMock(...args),
+}));
+
+vi.mock('../embed.js', () => ({
+  __esModule: true,
+  embedBatch: (...args: unknown[]) => embedBatchMock(...args),
+}));
+
+vi.mock('../store.js', () => ({
+  __esModule: true,
+  storeChunks: (...args: unknown[]) => storeChunksMock(...args),
+}));
+
+const documentFixture = {
+  id: 'doc-123',
+  collection_id: 'col-1',
+  title: 'test.txt',
+  file_path: '/tmp/doc-123.txt',
+  content_type: 'text/plain',
+  file_size: 12,
+  source_url: null,
+  status: 'pending',
+  error_message: null,
+  metadata: {},
+  created_at: new Date(),
+  processed_at: null,
+  updated_at: new Date(),
+};
+
+const chunksFixture = [
+  { text: 'chunk-1', index: 0, metadata: { startOffset: 0, endOffset: 7 } },
+  { text: 'chunk-2', index: 1, metadata: { startOffset: 7, endOffset: 14 } },
+];
+
+const embeddingsFixture = [
+  [0.1, 0.2],
+  [0.3, 0.4],
+];
+
+describe('ingestDocument', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    getDocumentMock.mockResolvedValue({ ...documentFixture });
+    readFileMock.mockResolvedValue(Buffer.from('file-content'));
+    extractMock.mockResolvedValue({ text: 'combined text', metadata: { pageCount: 1 } });
+    chunkTextMock.mockReturnValue([...chunksFixture]);
+    embedBatchMock.mockResolvedValue([...embeddingsFixture]);
+    storeChunksMock.mockResolvedValue(undefined);
+  });
+
+  it('orchestrates the full pipeline and updates statuses sequentially', async () => {
+    const { ingestDocument } = await import('../orchestrator.js');
+
+    await ingestDocument('doc-123', {
+      chunk: { maxSize: 100, overlap: 20 },
+      embed: { model: 'custom-model', batchSize: 2 },
+    });
+
+    expect(getDocumentMock).toHaveBeenCalledWith('doc-123');
+    expect(readFileMock).toHaveBeenCalledWith('/tmp/doc-123.txt');
+    expect(extractMock).toHaveBeenCalledWith(expect.any(Buffer), 'text/plain', 'test.txt');
+    expect(chunkTextMock).toHaveBeenCalledWith(
+      'combined text',
+      { maxSize: 100, overlap: 20 },
+      {
+        pageCount: 1,
+        documentId: 'doc-123',
+      }
+    );
+    expect(embedBatchMock).toHaveBeenCalledWith(['chunk-1', 'chunk-2'], {
+      model: 'custom-model',
+      batchSize: 2,
+    });
+    expect(storeChunksMock).toHaveBeenCalledWith('doc-123', chunksFixture, embeddingsFixture, {
+      embeddingModel: 'custom-model',
+    });
+
+    expect(updateDocumentStatusMock).toHaveBeenNthCalledWith(1, 'doc-123', 'extracting');
+    expect(updateDocumentStatusMock).toHaveBeenNthCalledWith(2, 'doc-123', 'chunking');
+    expect(updateDocumentStatusMock).toHaveBeenNthCalledWith(3, 'doc-123', 'embedding');
+    expect(updateDocumentStatusMock).toHaveBeenLastCalledWith('doc-123', 'complete');
+  });
+
+  it('short-circuits embedding when no chunks are produced', async () => {
+    chunkTextMock.mockReturnValueOnce([]);
+
+    const { ingestDocument } = await import('../orchestrator.js');
+
+    await ingestDocument('doc-123');
+
+    expect(embedBatchMock).not.toHaveBeenCalled();
+    expect(storeChunksMock).toHaveBeenCalledWith('doc-123', [], []);
+    expect(updateDocumentStatusMock).toHaveBeenNthCalledWith(1, 'doc-123', 'extracting');
+    expect(updateDocumentStatusMock).toHaveBeenNthCalledWith(2, 'doc-123', 'chunking');
+    expect(updateDocumentStatusMock).toHaveBeenLastCalledWith('doc-123', 'complete');
+  });
+
+  it('marks document as error when any stage fails', async () => {
+    extractMock.mockRejectedValueOnce(new Error('boom'));
+
+    const { ingestDocument } = await import('../orchestrator.js');
+
+    await expect(ingestDocument('doc-123')).rejects.toThrow('boom');
+
+    const statuses = updateDocumentStatusMock.mock.calls.map((call) => call[1]);
+    expect(statuses).toContain('error');
+    const errorCall = updateDocumentStatusMock.mock.calls.find((call) => call[1] === 'error');
+    expect(errorCall?.[2]).toBe('boom');
+    expect(storeChunksMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/pipeline/chunk.ts
+++ b/apps/server/src/pipeline/chunk.ts
@@ -1,0 +1,246 @@
+export interface ChunkOptions {
+  /** Maximum number of characters per chunk (default: 800). */
+  maxSize?: number;
+  /** Number of overlapping characters between consecutive chunks (default: 150). */
+  overlap?: number;
+  /** Custom paragraph separator detection (default: two or more newlines). */
+  paragraphSeparator?: RegExp;
+}
+
+export interface ChunkMetadata {
+  /** Inclusive start offset within the source text. */
+  startOffset: number;
+  /** Exclusive end offset within the source text. */
+  endOffset: number;
+  /** Optional heading inferred from the chunk content. */
+  heading?: string;
+  /** Optional section metadata (reserved for future use). */
+  section?: string;
+  /** Optional page number if present in the source metadata. */
+  pageNumber?: number;
+  [key: string]: unknown;
+}
+
+export interface Chunk {
+  /** The text content of the chunk. */
+  text: string;
+  /** Position of the chunk within the generated sequence (0-based). */
+  index: number;
+  /** Metadata describing this chunk. */
+  metadata: ChunkMetadata;
+}
+
+interface NormalisedOptions {
+  maxSize: number;
+  overlap: number;
+  paragraphSeparator: RegExp;
+}
+
+const DEFAULTS: NormalisedOptions = {
+  maxSize: 800,
+  overlap: 150,
+  paragraphSeparator: /\n{2,}/g,
+};
+
+/**
+ * Splits free-form text into overlapping chunks sized for downstream embedding.
+ */
+export function chunkText(
+  text: string,
+  options: ChunkOptions = {},
+  documentMetadata: Record<string, unknown> = {}
+): Chunk[] {
+  const normalisedText = normaliseNewlines(text).trim();
+
+  if (normalisedText.length === 0) {
+    return [];
+  }
+
+  const config: NormalisedOptions = {
+    maxSize: options.maxSize ?? DEFAULTS.maxSize,
+    overlap: options.overlap ?? DEFAULTS.overlap,
+    paragraphSeparator: options.paragraphSeparator ?? DEFAULTS.paragraphSeparator,
+  };
+
+  if (config.maxSize <= 0) {
+    throw new Error('chunk maxSize must be greater than zero');
+  }
+
+  if (config.overlap < 0) {
+    throw new Error('chunk overlap cannot be negative');
+  }
+
+  if (config.overlap >= config.maxSize) {
+    throw new Error('chunk overlap must be smaller than maxSize');
+  }
+
+  const chunks: Chunk[] = [];
+  const length = normalisedText.length;
+  let start = 0;
+  let chunkIndex = 0;
+
+  while (start < length) {
+    const { end, hardLimit } = determineChunkEnd(normalisedText, start, config);
+    const rawChunk = normalisedText.slice(start, end);
+    const trimmedChunk = rawChunk.replace(/\s+$/u, '');
+
+    if (trimmedChunk.length === 0) {
+      // Prevent infinite loops when encountering excessive whitespace.
+      start = hardLimit;
+      continue;
+    }
+
+    const trailingWhitespace = rawChunk.length - trimmedChunk.length;
+    const startOffset = start;
+    const endOffset = end - trailingWhitespace;
+
+    const candidate: Chunk = {
+      text: trimmedChunk,
+      index: chunkIndex,
+      metadata: {
+        ...documentMetadata,
+        startOffset,
+        endOffset,
+        heading:
+          extractHeading(trimmedChunk.trimStart()) ??
+          (documentMetadata.heading as string | undefined),
+      },
+    };
+
+    const previous = chunks[chunks.length - 1];
+    if (previous && candidate.metadata.endOffset <= previous.metadata.endOffset) {
+      start = endOffset;
+      continue;
+    }
+
+    chunkIndex += 1;
+    chunks.push(candidate);
+
+    if (end >= length) {
+      break;
+    }
+
+    let nextStart = end - config.overlap;
+    if (nextStart <= start) {
+      nextStart = end;
+    }
+
+    start = nextStart;
+  }
+
+  return chunks;
+}
+
+function determineChunkEnd(
+  text: string,
+  start: number,
+  config: NormalisedOptions
+): { end: number; hardLimit: number } {
+  const hardLimit = Math.min(start + config.maxSize, text.length);
+
+  if (hardLimit === text.length) {
+    return { end: hardLimit, hardLimit };
+  }
+
+  const paragraphBreak = findParagraphBreak(text, start, hardLimit, config.paragraphSeparator);
+  if (paragraphBreak > start) {
+    return { end: paragraphBreak, hardLimit };
+  }
+
+  const sentenceBoundary = findLastSentenceBoundary(text, start, hardLimit);
+  if (sentenceBoundary > start) {
+    return { end: sentenceBoundary, hardLimit };
+  }
+
+  const extendedLimit = Math.min(start + config.maxSize + config.overlap, text.length);
+  if (extendedLimit > hardLimit) {
+    const forwardBoundary = findFirstSentenceBoundary(text, hardLimit, extendedLimit);
+    if (forwardBoundary > hardLimit) {
+      return { end: forwardBoundary, hardLimit: extendedLimit };
+    }
+  }
+
+  return { end: hardLimit, hardLimit };
+}
+
+function findParagraphBreak(
+  text: string,
+  start: number,
+  limit: number,
+  paragraphSeparator: RegExp
+): number {
+  paragraphSeparator.lastIndex = start;
+  let candidate = -1;
+  while (true) {
+    const match = paragraphSeparator.exec(text);
+    if (!match || match.index >= limit) {
+      break;
+    }
+
+    candidate = match.index;
+  }
+
+  paragraphSeparator.lastIndex = 0;
+
+  if (candidate <= start) {
+    return -1;
+  }
+
+  // Include the separator characters in the chunk to avoid leading newlines later.
+  const separatorLength = (text.slice(candidate).match(/^\n+/) ?? [''])[0].length;
+  return candidate + separatorLength;
+}
+
+function findLastSentenceBoundary(text: string, start: number, limit: number): number {
+  if (limit <= start) {
+    return -1;
+  }
+
+  const window = text.slice(start, limit);
+  const punctuationMatches = window.matchAll(/[.!?]["')\]]*\s+/g);
+  let boundary = -1;
+
+  for (const match of punctuationMatches) {
+    const index = start + (match.index ?? 0) + match[0].length;
+    if (index <= limit) {
+      boundary = index;
+    }
+  }
+
+  return boundary;
+}
+
+function findFirstSentenceBoundary(text: string, rangeStart: number, rangeEnd: number): number {
+  if (rangeEnd <= rangeStart) {
+    return -1;
+  }
+
+  const window = text.slice(rangeStart, rangeEnd);
+  const punctuationMatches = window.matchAll(/[.!?]["')\]]*\s+/g);
+
+  for (const match of punctuationMatches) {
+    const index = rangeStart + (match.index ?? 0) + match[0].length;
+    if (index <= rangeEnd) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function extractHeading(chunk: string): string | undefined {
+  const firstLine = chunk.split('\n', 1)[0]?.trim();
+  if (!firstLine) {
+    return undefined;
+  }
+
+  if (firstLine.length <= 120 && /^[#A-Z]/.test(firstLine)) {
+    return firstLine;
+  }
+
+  return undefined;
+}
+
+function normaliseNewlines(text: string): string {
+  return text.replace(/\r\n?/g, '\n');
+}

--- a/apps/server/src/pipeline/embed.ts
+++ b/apps/server/src/pipeline/embed.ts
@@ -1,0 +1,154 @@
+import { Ollama } from 'ollama';
+
+export interface EmbedOptions {
+  /** Embedding model served by Ollama (default: `nomic-embed-text`). */
+  model?: string;
+  /** Maximum number of texts to embed in parallel (default: 10). */
+  batchSize?: number;
+  /** Number of retries for transient Ollama failures (default: 3). */
+  maxRetries?: number;
+  /** Delay between retries in milliseconds (default: 250). */
+  retryDelayMs?: number;
+}
+
+interface EmbedRuntimeConfig {
+  model: string;
+  maxRetries: number;
+  retryDelayMs: number;
+}
+
+const DEFAULT_MODEL = 'nomic-embed-text';
+const DEFAULT_BATCH_SIZE = 10;
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_RETRY_DELAY_MS = 250;
+
+interface EmbeddingsClient {
+  embeddings: (input: { model: string; prompt: string }) => Promise<
+    { embedding: number[] } | null | undefined
+  >;
+}
+
+let cachedClient: EmbeddingsClient | null = null;
+
+function getOllamaClient(): EmbeddingsClient {
+  if (cachedClient) {
+    return cachedClient;
+  }
+
+  const host = process.env.OLLAMA_HOST ?? 'http://localhost:11434';
+  cachedClient = new Ollama({ host });
+  return cachedClient;
+}
+
+export function __setOllamaClientForTesting(client: EmbeddingsClient | null): void {
+  cachedClient = client;
+}
+
+export async function embedText(text: string, options: EmbedOptions = {}): Promise<number[]> {
+  const config = resolveRuntimeConfig(options);
+
+  const embedding = await withRetry(
+    async () => {
+      const response = await getOllamaClient().embeddings({
+        model: config.model,
+        prompt: text,
+      });
+
+      return normalizeEmbedding(response);
+    },
+    config.maxRetries,
+    config.retryDelayMs
+  );
+
+  return embedding;
+}
+
+export async function embedBatch(texts: string[], options: EmbedOptions = {}): Promise<number[][]> {
+  if (texts.length === 0) {
+    return [];
+  }
+
+  const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+  if (batchSize <= 0) {
+    throw new Error('Embedding batchSize must be greater than zero');
+  }
+
+  const results: number[][] = [];
+
+  for (let i = 0; i < texts.length; i += batchSize) {
+    const batch = texts.slice(i, i + batchSize);
+    const embeddings = await Promise.all(batch.map((text) => embedText(text, options)));
+    results.push(...embeddings);
+  }
+
+  return results;
+}
+
+function resolveRuntimeConfig(options: EmbedOptions): EmbedRuntimeConfig {
+  const model = options.model?.trim() ?? DEFAULT_MODEL;
+  if (model.length === 0) {
+    throw new Error('Embedding model cannot be empty');
+  }
+
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+  if (maxRetries < 0) {
+    throw new Error('Embedding maxRetries cannot be negative');
+  }
+
+  const retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+  if (retryDelayMs < 0) {
+    throw new Error('Embedding retryDelayMs cannot be negative');
+  }
+
+  return { model, maxRetries, retryDelayMs };
+}
+
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  maxRetries: number,
+  retryDelayMs: number
+): Promise<T> {
+  let attempt = 0;
+  // We allow the initial attempt plus `maxRetries` additional attempts.
+  // Example: maxRetries = 3 → up to 4 total attempts.
+  while (true) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt >= maxRetries) {
+        throw error;
+      }
+
+      attempt += 1;
+      if (retryDelayMs > 0) {
+        await delay(retryDelayMs * attempt);
+      }
+    }
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function normalizeEmbedding(response: { embedding?: unknown } | null | undefined): number[] {
+  if (!response || !Array.isArray(response.embedding)) {
+    throw new Error('Ollama embedding response missing embedding array');
+  }
+
+  const embedding = response.embedding.map((value) => {
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+      throw new Error('Embedding values must be numeric');
+    }
+
+    return value;
+  });
+
+  if (embedding.length === 0) {
+    throw new Error('Embedding array must contain at least one value');
+  }
+
+  return embedding;
+}

--- a/apps/server/src/pipeline/embed.ts
+++ b/apps/server/src/pipeline/embed.ts
@@ -1,0 +1,154 @@
+import { Ollama } from 'ollama';
+
+export interface EmbedOptions {
+  /** Embedding model served by Ollama (default: `nomic-embed-text`). */
+  model?: string;
+  /** Maximum number of texts to embed in parallel (default: 10). */
+  batchSize?: number;
+  /** Number of retries for transient Ollama failures (default: 3). */
+  maxRetries?: number;
+  /** Delay between retries in milliseconds (default: 250). */
+  retryDelayMs?: number;
+}
+
+interface EmbedRuntimeConfig {
+  model: string;
+  maxRetries: number;
+  retryDelayMs: number;
+}
+
+const DEFAULT_MODEL = 'nomic-embed-text';
+const DEFAULT_BATCH_SIZE = 10;
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_RETRY_DELAY_MS = 250;
+
+interface EmbeddingsClient {
+  embeddings: (input: { model: string; prompt: string }) => Promise<
+    { embedding: number[] } | null | undefined
+  >;
+}
+
+let cachedClient: EmbeddingsClient | null = null;
+
+function getOllamaClient(): EmbeddingsClient {
+  if (cachedClient) {
+    return cachedClient;
+  }
+
+  const host = process.env.OLLAMA_HOST ?? 'http://localhost:11434';
+  cachedClient = new Ollama({ host });
+  return cachedClient;
+}
+
+export function __setOllamaClientForTesting(client: EmbeddingsClient | null): void {
+  cachedClient = client;
+}
+
+export async function embedText(text: string, options: EmbedOptions = {}): Promise<number[]> {
+  const config = resolveRuntimeConfig(options);
+
+  const embedding = await withRetry(
+    async () => {
+      const response = await getOllamaClient().embeddings({
+        model: config.model,
+        prompt: text,
+      });
+
+      return normalizeEmbedding(response);
+    },
+    config.maxRetries,
+    config.retryDelayMs
+  );
+
+  return embedding;
+}
+
+export async function embedBatch(texts: string[], options: EmbedOptions = {}): Promise<number[][]> {
+  if (texts.length === 0) {
+    return [];
+  }
+
+  const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+  if (batchSize <= 0) {
+    throw new Error('Embedding batchSize must be greater than zero');
+  }
+
+  const results: number[][] = [];
+
+  for (let i = 0; i < texts.length; i += batchSize) {
+    const batch = texts.slice(i, i + batchSize);
+    const embeddings = await Promise.all(batch.map((text) => embedText(text, options)));
+    results.push(...embeddings);
+  }
+
+  return results;
+}
+
+function resolveRuntimeConfig(options: EmbedOptions): EmbedRuntimeConfig {
+  const model = options.model?.trim() ?? DEFAULT_MODEL;
+  if (model.length === 0) {
+    throw new Error('Embedding model cannot be empty');
+  }
+
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+  if (maxRetries < 0) {
+    throw new Error('Embedding maxRetries cannot be negative');
+  }
+
+  const retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+  if (retryDelayMs < 0) {
+    throw new Error('Embedding retryDelayMs cannot be negative');
+  }
+
+  return { model, maxRetries, retryDelayMs };
+}
+
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  maxRetries: number,
+  retryDelayMs: number
+): Promise<T> {
+  let attempt = 0;
+  // We allow the initial attempt plus `maxRetries` additional attempts.
+  // Example: maxRetries = 3 → up to 4 total attempts.
+  while (true) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt >= maxRetries) {
+        throw error;
+      }
+
+      attempt += 1;
+      if (retryDelayMs > 0) {
+        await delay(retryDelayMs * attempt);
+      }
+    }
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function normalizeEmbedding(response: { embedding?: unknown } | null | undefined): number[] {
+  if (!response || !Array.isArray(response.embedding)) {
+    throw new Error('Ollama embedding response missing embedding array');
+  }
+
+  const embedding = response.embedding.map((value) => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      throw new Error('Embedding values must be finite numbers');
+    }
+
+    return value;
+  });
+
+  if (embedding.length === 0) {
+    throw new Error('Embedding array must contain at least one value');
+  }
+
+  return embedding;
+}

--- a/apps/server/src/pipeline/orchestrator.ts
+++ b/apps/server/src/pipeline/orchestrator.ts
@@ -1,0 +1,80 @@
+import fs from 'node:fs/promises';
+import { type Document, getDocument, updateDocumentStatus } from '@synthesis/db';
+import type { ChunkOptions } from './chunk.js';
+import { chunkText } from './chunk.js';
+import type { EmbedOptions } from './embed.js';
+import { embedBatch } from './embed.js';
+import { extract } from './extract.js';
+import { storeChunks } from './store.js';
+
+export interface IngestOptions {
+  /** Chunking configuration overrides. */
+  chunk?: ChunkOptions;
+  /** Embedding configuration overrides. */
+  embed?: EmbedOptions;
+}
+
+type ReadyDocument = Document & {
+  file_path: string;
+  content_type: string;
+};
+
+function assertDocumentReady(
+  document: Document | null,
+  documentId: string
+): asserts document is ReadyDocument {
+  if (!document) {
+    throw new Error(`Document ${documentId} not found`);
+  }
+
+  if (!document.file_path) {
+    throw new Error(`Document ${documentId} is missing file_path`);
+  }
+
+  if (!document.content_type) {
+    throw new Error(`Document ${documentId} is missing content_type`);
+  }
+}
+
+export async function ingestDocument(
+  documentId: string,
+  options: IngestOptions = {}
+): Promise<void> {
+  const document = await getDocument(documentId);
+  assertDocumentReady(document, documentId);
+
+  const buffer = await fs.readFile(document.file_path);
+
+  try {
+    await updateDocumentStatus(documentId, 'extracting');
+    const extraction = await extract(buffer, document.content_type, document.title);
+
+    await updateDocumentStatus(documentId, 'chunking');
+    const chunks = chunkText(extraction.text, options.chunk, {
+      ...extraction.metadata,
+      documentId,
+    });
+
+    if (chunks.length === 0) {
+      await storeChunks(documentId, [], []);
+      await updateDocumentStatus(documentId, 'complete');
+      return;
+    }
+
+    await updateDocumentStatus(documentId, 'embedding');
+    const embeddings = await embedBatch(
+      chunks.map((chunk) => chunk.text),
+      options.embed
+    );
+
+    await storeChunks(documentId, chunks, embeddings, {
+      embeddingModel: options.embed?.model,
+    });
+
+    await updateDocumentStatus(documentId, 'complete');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await updateDocumentStatus(documentId, 'error', message);
+    throw error;
+  }
+}

--- a/apps/server/src/pipeline/store.ts
+++ b/apps/server/src/pipeline/store.ts
@@ -1,0 +1,96 @@
+import { deleteDocumentChunks, upsertChunk } from '@synthesis/db';
+import type { Chunk } from './chunk.js';
+
+const DEFAULT_MAX_CONCURRENT_UPSERTS = 10;
+
+export interface StoreChunksOptions {
+  /** Embedding model name stored alongside vectors. */
+  embeddingModel?: string;
+  /** Optional cap on concurrent upsert operations; defaults to 10 when invalid or unspecified. */
+  maxConcurrentUpserts?: number;
+}
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+export async function storeChunks(
+  documentId: string,
+  chunks: Chunk[],
+  embeddings: number[][],
+  options: StoreChunksOptions = {}
+): Promise<void> {
+  if (embeddings.length > 0 && embeddings.length !== chunks.length) {
+    throw new Error('Chunks and embeddings length mismatch');
+  }
+
+  await deleteDocumentChunks(documentId);
+
+  if (chunks.length === 0) {
+    return;
+  }
+
+  const embeddingModel =
+    options.embeddingModel ?? process.env.EMBEDDING_MODEL ?? 'nomic-embed-text';
+  const MAX_RETRIES = 3;
+  const INITIAL_BACKOFF_MS = 100;
+  const BACKOFF_FACTOR = 2;
+
+  const retryWithBackoff = async <T>(operation: () => Promise<T>): Promise<T> => {
+    let attempt = 0;
+    let delay = INITIAL_BACKOFF_MS;
+
+    // Try the operation with exponential backoff to cushion transient DB errors.
+    while (true) {
+      try {
+        return await operation();
+      } catch (error) {
+        attempt += 1;
+        if (attempt >= MAX_RETRIES) {
+          throw error;
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        delay *= BACKOFF_FACTOR;
+      }
+    }
+  };
+
+  const providedConcurrency =
+    typeof options.maxConcurrentUpserts === 'number' && options.maxConcurrentUpserts > 0
+      ? options.maxConcurrentUpserts
+      : undefined;
+
+  const concurrency = Math.max(
+    1,
+    Math.min(providedConcurrency ?? DEFAULT_MAX_CONCURRENT_UPSERTS, chunks.length)
+  );
+  let nextIndex = 0;
+
+  const workers = Array.from({ length: concurrency }, async () => {
+    while (true) {
+      const currentIndex = nextIndex++;
+
+      if (currentIndex >= chunks.length) {
+        break;
+      }
+
+      const chunk = chunks[currentIndex];
+      const embedding = embeddings[currentIndex];
+
+      await retryWithBackoff(() =>
+        upsertChunk({
+          doc_id: documentId,
+          chunk_index: chunk.index,
+          text: chunk.text,
+          token_count: estimateTokens(chunk.text),
+          embedding,
+          embedding_model: embedding ? embeddingModel : undefined,
+          metadata: chunk.metadata,
+        })
+      );
+    }
+  });
+
+  await Promise.all(workers);
+}


### PR DESCRIPTION
## Summary
- implement sentence-aware chunking with metadata tracking in `apps/server/src/pipeline/chunk.ts`
- add Ollama embedding client, retries, and batching in `apps/server/src/pipeline/embed.ts`
- orchestrate extract → chunk → embed → store in `apps/server/src/pipeline/orchestrator.ts` and update `/api/ingest`
- persist chunks with configurable concurrency in `apps/server/src/pipeline/store.ts`, add unit tests, and document results in `PHASE_2_SUMMARY.md`

## Testing
- pnpm --filter @synthesis/server test
- curl -F "collection_id=<uuid>" -F "files=@/home/kngpnn/dev/synthesis/20MB-TESTFILE.ORG.pdf" http://localhost:3333/api/ingest

Closes #6, #9, #12, #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - End-to-end document ingestion pipeline available via the API: extract → chunk → embed → store.
  - Asynchronous ingestion with clear progress statuses (extracting, chunking, embedding, complete/error).
  - Persistent storage of chunks and embeddings for later retrieval.
  - Improved reliability: batching, retries, and configurable concurrent storage for large files.

- **Documentation**
  - Added Phase 2 overview with acceptance checklist and testing guidance.

- **Tests**
  - Comprehensive unit and e2e validation for chunking, embedding, orchestration, and ingestion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->