### PR TITLE
Phase 3: Messages API agent + search

### DIFF
--- a/PHASE_3_SUMMARY.md
+++ b/PHASE_3_SUMMARY.md
@@ -12,7 +12,7 @@ Implemented production-ready semantic search and integrated the Claude Messages 
 
 ---
 
-## ✅ Features Implemented
+## Features Implemented
 
 - [x] Vector search service with cosine similarity and citations (`searchCollection`)
 - [x] `/api/search` endpoint returning top-k chunk matches

--- a/PHASE_3_SUMMARY.md
+++ b/PHASE_3_SUMMARY.md
@@ -1,0 +1,174 @@
+# Phase Summary: Phase 3 – Search & Agent Tools
+
+**Date:** 2025-10-08  
+**Agent:** Codex (Builder)  
+**Duration:** 2 days
+
+---
+
+## 📋 Overview
+
+Implemented production-ready semantic search and integrated the Claude Messages API agent loop. Added a full MCP-style tool suite (search, ingestion, web crawl, management, summaries), refactored the agent off the buggy SDK, and refreshed supporting docs/issue templates. Prior SDK-based implementation is archived in git stash for future comparison once the upstream bug is fixed. End-to-end RAG workflows (fetch → ingest → embed → search → answer) were validated after installing Playwright’s headless Chromium bundle.
+
+---
+
+## ✅ Features Implemented
+
+- [x] Vector search service with cosine similarity and citations (`searchCollection`)
+- [x] `/api/search` endpoint returning top-k chunk matches
+- [x] Claude Messages API agent loop with nine tools and `/api/agent/chat`
+- [x] Documentation & issue template updates covering new agent architecture
+
+---
+
+## 📁 Files Changed
+
+### Added
+- `apps/server/src/agent/utils/storage.ts` – Helpers for downloading, inferring MIME/extension, and writing document files
+- `apps/server/src/agent/__tests__/agent.test.ts` – Unit tests for the manual Messages API loop
+- `apps/server/src/agent/__tests__/tools.test.ts` – Unit tests covering each tool executor
+
+### Modified (highlights)
+- `apps/server/src/agent/agent.ts` – Replaced SDK Agent wrapper with custom Messages API loop, tool execution, and usage tracking
+- `apps/server/src/agent/tools.ts` – Converted tools to `{definition, executor}` pairs, added fetch/add/list/delete/restart/summarize implementations
+- `apps/server/src/routes/agent.ts` – Wired POST `/api/agent/chat` into the new agent runner
+- `apps/server/src/routes/search.ts` / `apps/server/src/services/search.ts` – Vector search endpoint and service
+- `docs/04_AGENT_TOOLS.md`, `docs/09_BUILD_PLAN.md`, `docs/14_GITHUB_ISSUES.md`, `docs/15_AGENT_PROMPTS.md` – Updated architecture guidance, plans, and issues to reflect Messages API usage and expanded tool set
+- `apps/server/package.json` / `pnpm-lock.yaml` – Removed `@anthropic-ai/claude-agent-sdk`, pinned `@anthropic-ai/sdk@^0.65.0`
+
+### Deleted
+- n/a
+
+---
+
+## 🧪 Tests Added
+
+### Unit Tests
+- `apps/server/src/agent/__tests__/agent.test.ts` – Validates multi-turn tool loop with mocked Anthropic responses
+- `apps/server/src/agent/__tests__/tools.test.ts` – Covers every tool executor, mocks storage/Playwright/Anthropic
+- `apps/server/src/routes/__tests__/search.test.ts` / `apps/server/src/services/__tests__/search.test.ts` – Ensure search API/service behaviour
+
+### Test Results
+```
+pnpm --filter @synthesis/server typecheck
+pnpm --filter @synthesis/server exec -- vitest run --pool=vmThreads
+✓ All suites passing (28 tests)
+```
+
+### Manual End-to-End Validation
+- Playwright browser installed via `pnpm --filter @synthesis/server exec -- npx playwright install chromium`
+- `fetch_web_content` scraped https://example.com, queued ingestion, and kicked off the pipeline
+- `get_document_status` and `restart_ingest` monitored/replayed processing
+- `search_rag` retrieved vector matches and the agent synthesized a citation-rich answer
+
+---
+
+## 🎯 Acceptance Criteria
+
+- [x] **Vector search service** returns relevant chunks with citations – ✅ Complete
+- [x] **POST /api/search** returns top-k matches scoped by collection – ✅ Complete
+- [x] **Agent uses search tool automatically** via `/api/agent/chat` – ✅ Complete
+- [x] **Agent responses cite sources** and leverage retrieved documents – ✅ Complete
+
+---
+
+## ⚠️ Known Issues
+
+### Issue 1: Anthropic Claude Agent SDK binary crash on WSL2
+- **Severity:** Medium
+- **Description:** Upstream SDK bundles native binaries incompatible with our WSL2 environment, triggering RuntimeException on load.
+- **Impact:** Prevents us from using the SDK’s automation helpers; necessitated refactor to direct Messages API.
+- **Workaround:** Custom Messages API loop implemented; prior SDK-based code preserved in git stash for easy reintroduction once fixed.
+- **Tracked:** Upstream issue pending; local note for Phase 4 follow-up.
+- **Plan:** Periodically retry SDK once Anthropic releases a compatible build.
+
+---
+
+## 💥 Breaking Changes
+
+### None
+✅ No breaking changes in this phase.
+
+---
+
+## 📦 Dependencies Added/Updated
+
+### Removed Dependencies
+```json
+{
+  "@anthropic-ai/claude-agent-sdk": "removed"
+}
+```
+**Reason:** Binary incompatibility under WSL2 forced migration to direct Messages API.
+
+### Updated Dependencies
+```json
+{
+  "@anthropic-ai/sdk": "^0.27.0 → ^0.65.0"
+}
+```
+**Reason:** Needed streaming + tool support available in latest SDK.
+
+---
+
+## 🔗 Dependencies for Next Phase
+
+1. **Playwright tooling** already configured for web crawling; Phase 4 can build on the `fetch_web_content` executor.
+2. **Ingestion pipeline** ready for retry/resume via `restart_ingest` – usable by autonomy enhancements.
+3. **Search API** now stable; front-end/UI work can rely on `/api/search` without further backend changes.
+
+---
+
+## 📊 Metrics
+
+### Testing
+- Tests added: 7 suites (28 assertions)
+- Test execution time: ~2s via Vitest
+
+### Code Quality
+- LOC delta: ≈ +1,200 / −400 (tools + tests + docs)
+- Lint/typecheck: ✅ `pnpm --filter @synthesis/server typecheck`
+
+### Performance (qualitative)
+- Vector search response time unchanged (server-side DB query only)
+- Agent loop adds ≤1 extra network roundtrip per tool call; acceptable for Phase 3
+
+---
+
+## 🔍 Review Checklist
+
+### Code Quality
+- [x] TypeScript best practices (strict mode, typed executors)
+- [x] Focused, testable functions (tool executors, agent loop helpers)
+- [x] Descriptive naming; magic values abstracted (constants for tool names)
+- [x] Structured error handling with friendly tool messages
+- [x] No stray console.log (server logging uses Fastify logger)
+
+### Testing
+- [x] Unit tests for new logic
+- [x] Edge/error cases (missing docs, confirm flag, no chunks)
+- [x] External dependencies mocked (Playwright, Anthropic, DB)
+- [x] Total runtime <5s
+
+### Security & Performance
+- [x] Parameterized queries via pg client
+- [x] Input validation with Zod
+- [x] No N+1 behaviour (single queries per tool)
+
+### Documentation
+- [x] Docs/plan/issue templates updated to reflect Messages API loop
+- [x] Environment requirements clarified (`ANTHROPIC_API_KEY`, etc.)
+
+---
+
+## 📝 Notes for Reviewers
+
+- Prior Claude Agent SDK implementation has been stashed (`git stash show --stat` for details) for easy reapply once Anthropic ships a fixed build.
+- Ensure `ANTHROPIC_API_KEY`, database, Ollama, and storage env vars are set before manual E2E testing.
+- Tool executors return Markdown-formatted strings; caller handles JSON serialization.
+
+### Testing Instructions
+```bash
+pnpm --filter @synthesis/server typecheck
+pnpm --filter @synthesis/server exec -- vitest run --pool=vmThreads
+```

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -1,0 +1,11 @@
+# Database
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/synthesis
+
+# Anthropic API
+ANTHROPIC_API_KEY=your-api-key-here
+
+# Ollama
+OLLAMA_BASE_URL=http://localhost:11434
+
+# Storage
+STORAGE_PATH=./storage

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.27.0",
+    "@anthropic-ai/sdk": "^0.65.0",
     "@fastify/cors": "^9.0.1",
     "@fastify/multipart": "^8.3.0",
     "@synthesis/db": "workspace:*",

--- a/apps/server/src/agent/__tests__/agent.test.ts
+++ b/apps/server/src/agent/__tests__/agent.test.ts
@@ -1,0 +1,128 @@
+import type { Pool } from 'pg';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const anthropicCreateMock = vi.hoisted(() => vi.fn());
+const searchExecutorMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue('Tool search_rag executed successfully.')
+);
+const buildAgentToolsMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    tools: [
+      {
+        name: 'search_rag',
+        description: 'mock tool',
+        input_schema: { type: 'object', properties: {} },
+      },
+    ],
+    toolExecutors: {
+      search_rag: searchExecutorMock,
+    },
+  }))
+);
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  __esModule: true,
+  default: vi.fn().mockImplementation(() => ({
+    messages: {
+      create: anthropicCreateMock,
+    },
+  })),
+}));
+
+vi.mock(
+  '../tools.js',
+  () => ({
+    __esModule: true,
+    buildAgentTools: buildAgentToolsMock,
+  }),
+  { virtual: true }
+);
+
+let runAgentChat: typeof import('../agent.js')['runAgentChat'];
+
+beforeAll(async () => {
+  ({ runAgentChat } = await import('../agent.js'));
+});
+
+describe('runAgentChat', () => {
+  const db = {} as Pool;
+
+  beforeEach(() => {
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+    vi.clearAllMocks();
+
+    anthropicCreateMock
+      .mockResolvedValueOnce({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tool-1',
+            name: 'search_rag',
+            input: { query: 'What is pgvector?' },
+          },
+        ],
+        usage: {
+          input_tokens: 50,
+          output_tokens: 10,
+        },
+      })
+      .mockResolvedValueOnce({
+        content: [
+          {
+            type: 'text',
+            text: 'pgvector is a PostgreSQL extension for vector similarity search.',
+          },
+        ],
+        usage: {
+          input_tokens: 20,
+          output_tokens: 30,
+        },
+      });
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(process.env, 'ANTHROPIC_API_KEY');
+  });
+
+  it('runs the agent loop, executes tools, and returns final response', async () => {
+    const history = [{ role: 'user' as const, content: 'Previous question' }];
+
+    const result = await runAgentChat(db, {
+      message: 'Tell me about pgvector.',
+      collectionId: '11111111-1111-4111-8111-111111111111',
+      history,
+    });
+
+    expect(buildAgentToolsMock).toHaveBeenCalledWith(db, {
+      collectionId: '11111111-1111-4111-8111-111111111111',
+    });
+
+    expect(anthropicCreateMock).toHaveBeenCalledTimes(2);
+    expect(searchExecutorMock).toHaveBeenCalledWith({ query: 'What is pgvector?' });
+
+    expect(result.message).toBe('pgvector is a PostgreSQL extension for vector similarity search.');
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0]).toMatchObject({
+      id: 'tool-1',
+      tool: 'search_rag',
+      status: 'completed',
+      result: 'Tool search_rag executed successfully.',
+    });
+
+    expect(result.usage).toEqual({
+      input_tokens: 70,
+      output_tokens: 40,
+    });
+  });
+
+  it('throws if API key missing', async () => {
+    Reflect.deleteProperty(process.env, 'ANTHROPIC_API_KEY');
+
+    await expect(
+      runAgentChat(db, {
+        message: 'Hi',
+        collectionId: '11111111-1111-4111-8111-111111111111',
+      })
+    ).rejects.toThrow(/ANTHROPIC_API_KEY/);
+  });
+});

--- a/apps/server/src/agent/__tests__/tools.test.ts
+++ b/apps/server/src/agent/__tests__/tools.test.ts
@@ -1,0 +1,281 @@
+import type { Pool } from 'pg';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildAgentTools,
+  createAddDocumentTool,
+  createFetchWebContentTool,
+  createListCollectionsTool,
+  createListDocumentsTool,
+  createSearchRagTool,
+  createSummarizeDocumentTool,
+} from '../tools.js';
+
+const searchCollectionMock = vi.hoisted(() => vi.fn());
+const createDocumentMock = vi.hoisted(() => vi.fn());
+const deleteDocumentChunksMock = vi.hoisted(() => vi.fn());
+const getDocumentMock = vi.hoisted(() => vi.fn());
+const getDocumentChunksMock = vi.hoisted(() => vi.fn());
+const ingestDocumentMock = vi.hoisted(() => vi.fn());
+const downloadRemoteFileMock = vi.hoisted(() => vi.fn());
+const readLocalFileMock = vi.hoisted(() => vi.fn());
+const inferContentTypeMock = vi.hoisted(() => vi.fn());
+const inferExtensionMock = vi.hoisted(() => vi.fn());
+const inferTitleMock = vi.hoisted(() => vi.fn());
+const isUrlMock = vi.hoisted(() => vi.fn());
+const writeDocumentFileMock = vi.hoisted(() => vi.fn());
+const deleteFileIfExistsMock = vi.hoisted(() => vi.fn());
+const chromiumLaunchMock = vi.hoisted(() => vi.fn());
+const anthropicCreateMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../services/search.js', () => ({
+  __esModule: true,
+  searchCollection: searchCollectionMock,
+}));
+
+vi.mock('@synthesis/db', () => ({
+  __esModule: true,
+  createDocument: createDocumentMock,
+  deleteDocumentChunks: deleteDocumentChunksMock,
+  getDocument: getDocumentMock,
+  getDocumentChunks: getDocumentChunksMock,
+}));
+
+vi.mock('../../pipeline/orchestrator.js', () => ({
+  __esModule: true,
+  ingestDocument: ingestDocumentMock,
+}));
+
+vi.mock('../utils/storage.js', () => ({
+  __esModule: true,
+  downloadRemoteFile: downloadRemoteFileMock,
+  readLocalFile: readLocalFileMock,
+  inferContentType: inferContentTypeMock,
+  inferExtension: inferExtensionMock,
+  inferTitle: inferTitleMock,
+  isUrl: isUrlMock,
+  writeDocumentFile: writeDocumentFileMock,
+  deleteFileIfExists: deleteFileIfExistsMock,
+}));
+
+vi.mock('playwright', () => ({
+  __esModule: true,
+  chromium: {
+    launch: chromiumLaunchMock,
+  },
+}));
+
+vi.mock('@anthropic-ai/sdk', () => {
+  return {
+    __esModule: true,
+    default: vi.fn().mockImplementation(() => ({
+      messages: {
+        create: anthropicCreateMock,
+      },
+    })),
+  };
+});
+
+function createDbMock() {
+  return {
+    query: vi.fn().mockResolvedValue({ rows: [] }),
+  } as unknown as Pool;
+}
+
+describe('agent tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('search tool proxies to searchCollection', async () => {
+    const db = createDbMock();
+    searchCollectionMock.mockResolvedValue({
+      query: 'Test',
+      results: [],
+      totalResults: 0,
+      searchTimeMs: 5,
+    });
+
+    const tool = createSearchRagTool(db, { collectionId: '11111111-1111-4111-8111-111111111111' });
+    await tool.executor({ query: 'Test', collection_id: '11111111-1111-4111-8111-111111111111' });
+
+    expect(searchCollectionMock).toHaveBeenCalledWith(db, {
+      query: 'Test',
+      collectionId: '11111111-1111-4111-8111-111111111111',
+      topK: 5,
+      minSimilarity: 0.5,
+    });
+  });
+
+  it('add_document tool downloads remote file and triggers ingestion', async () => {
+    const db = createDbMock();
+    const buffer = Buffer.from('example');
+
+    isUrlMock.mockReturnValue(true);
+    downloadRemoteFileMock.mockResolvedValue({
+      buffer,
+      contentType: 'application/pdf',
+      fileName: 'file.pdf',
+    });
+    inferContentTypeMock.mockReturnValue('application/pdf');
+    inferExtensionMock.mockReturnValue('.pdf');
+    inferTitleMock.mockReturnValue('Remote Doc');
+    createDocumentMock.mockResolvedValue({ id: 'doc-1' });
+    writeDocumentFileMock.mockResolvedValue('/storage/doc-1.pdf');
+    ingestDocumentMock.mockResolvedValue(undefined);
+
+    const tool = createAddDocumentTool(db, {
+      collectionId: '11111111-1111-4111-8111-111111111111',
+    });
+    const result = await tool.executor({
+      source: 'https://example.com/doc.pdf',
+      collection_id: '11111111-1111-4111-8111-111111111111',
+    });
+
+    expect(result).toContain('Document queued for ingestion');
+    expect(writeDocumentFileMock).toHaveBeenCalledWith(
+      '11111111-1111-4111-8111-111111111111',
+      'doc-1',
+      '.pdf',
+      buffer
+    );
+    expect(ingestDocumentMock).toHaveBeenCalledWith('doc-1');
+  });
+
+  it('fetch_web_content tool processes pages and queues ingestion', async () => {
+    const db = createDbMock();
+    const pageGoto = vi.fn();
+    const pageTitle = vi.fn().mockResolvedValue('Sample Page');
+    const pageEvaluate = vi.fn().mockResolvedValueOnce('Page content').mockResolvedValueOnce([]);
+    const browserClose = vi.fn();
+
+    chromiumLaunchMock.mockResolvedValue({
+      newPage: vi.fn().mockResolvedValue({
+        goto: pageGoto,
+        title: pageTitle,
+        evaluate: pageEvaluate,
+        $$eval: vi.fn().mockResolvedValue([]),
+      }),
+      close: browserClose,
+    });
+
+    createDocumentMock.mockResolvedValue({ id: 'doc-2' });
+    writeDocumentFileMock.mockResolvedValue('/storage/doc-2.md');
+
+    const tool = createFetchWebContentTool(db, {
+      collectionId: '11111111-1111-4111-8111-111111111111',
+    });
+    const result = await tool.executor({
+      url: 'https://example.com',
+      mode: 'single',
+      max_pages: 1,
+      collection_id: '11111111-1111-4111-8111-111111111111',
+    });
+
+    expect(result).toContain('Fetched and queued 1 page');
+    expect(createDocumentMock).toHaveBeenCalled();
+    expect(writeDocumentFileMock).toHaveBeenCalledWith(
+      '11111111-1111-4111-8111-111111111111',
+      'doc-2',
+      '.md',
+      expect.any(Buffer)
+    );
+    expect(browserClose).toHaveBeenCalled();
+  });
+
+  it('list_collections tool returns formatted collections', async () => {
+    const db = createDbMock();
+    (db.query as vi.Mock).mockResolvedValue({
+      rows: [
+        {
+          id: 'col-1',
+          name: 'Collection 1',
+          description: null,
+          doc_count: '2',
+          created_at: new Date('2024-01-01'),
+        },
+      ],
+    });
+
+    const tool = createListCollectionsTool(db);
+    const result = await tool.executor({});
+
+    expect(result).toContain('Collections retrieved');
+    expect(result).toContain('"doc_count": 2');
+  });
+
+  it('list_documents tool queries documents with defaults', async () => {
+    const db = createDbMock();
+    (db.query as vi.Mock).mockResolvedValue({
+      rows: [
+        {
+          id: 'doc-3',
+          title: 'Doc 3',
+          status: 'complete',
+          file_size: 100,
+          source_url: null,
+          created_at: new Date(),
+          updated_at: new Date(),
+          chunk_count: '5',
+          token_count: '500',
+        },
+      ],
+    });
+
+    const tool = createListDocumentsTool(db, {
+      collectionId: '11111111-1111-4111-8111-111111111111',
+    });
+    const result = await tool.executor({ collection_id: '11111111-1111-4111-8111-111111111111' });
+
+    expect(db.query as vi.Mock).toHaveBeenCalled();
+    expect(result).toContain('Retrieved 1 document');
+  });
+
+  it('summarize_document tool calls Anthropic API', async () => {
+    const db = createDbMock();
+    getDocumentMock.mockResolvedValue({
+      id: '11111111-1111-4111-8111-222222222222',
+      title: 'Doc 4',
+    });
+    getDocumentChunksMock.mockResolvedValue([
+      { id: 1, text: 'Chunk 1' },
+      { id: 2, text: 'Chunk 2' },
+    ]);
+
+    anthropicCreateMock.mockResolvedValue({
+      id: 'msg-1',
+      content: [{ type: 'text', text: 'Summary text' }],
+    });
+
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+
+    const tool = createSummarizeDocumentTool(db);
+    const result = await tool.executor({ doc_id: '11111111-1111-4111-8111-222222222222' });
+
+    expect(anthropicCreateMock).toHaveBeenCalled();
+    expect(result).toContain('Summary generated');
+
+    Reflect.deleteProperty(process.env, 'ANTHROPIC_API_KEY');
+  });
+
+  it('buildAgentTools returns full tool set with allowed names', () => {
+    const db = createDbMock();
+    const { tools, toolExecutors } = buildAgentTools(db, { collectionId: 'collection-1' });
+
+    const expectedNames = [
+      'search_rag',
+      'add_document',
+      'fetch_web_content',
+      'list_collections',
+      'list_documents',
+      'get_document_status',
+      'delete_document',
+      'restart_ingest',
+      'summarize_document',
+    ];
+
+    expect(tools.map((toolDef) => toolDef.name)).toEqual(expectedNames);
+    for (const name of expectedNames) {
+      expect(typeof toolExecutors[name]).toBe('function');
+    }
+  });
+});

--- a/apps/server/src/agent/agent.ts
+++ b/apps/server/src/agent/agent.ts
@@ -1,0 +1,288 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { ContentBlock, MessageParam, Tool } from '@anthropic-ai/sdk/resources/messages.js';
+import type { Pool } from 'pg';
+import { buildAgentTools } from './tools.js';
+
+export interface AgentConversationMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface AgentChatParams {
+  message: string;
+  collectionId: string;
+  history?: AgentConversationMessage[];
+}
+
+export interface AgentToolCall {
+  id: string;
+  tool: string;
+  input: unknown;
+  status: 'started' | 'completed' | 'error';
+  result?: unknown;
+  serverName?: string;
+}
+
+export interface AgentChatResult {
+  message: string;
+  toolCalls: AgentToolCall[];
+  history: AgentConversationMessage[];
+  usage?: Record<string, unknown>;
+}
+
+const BASE_SYSTEM_PROMPT = `You are an autonomous RAG assistant helping a developer manage documentation for multiple projects.
+
+Your capabilities:
+- Search the knowledge base across collections
+- Add documents from file paths or URLs
+- Fetch and process web documentation (crawl pages)
+- List and manage collections and documents
+- Provide answers with specific citations
+
+Guidelines:
+- Always cite sources with document title and page/section when available
+- When asked to add docs, proactively fetch and process them without asking for confirmation
+- If documentation is outdated, offer to update it
+- Be concise but thorough in your responses
+- Confirm destructive actions (delete) before executing
+- Use multiple tools in sequence when needed to complete a task
+
+Current context:
+- You have access to multiple project collections (Flutter, Supabase, etc.)
+- All operations are collection-scoped
+- The user can switch between collections in the UI`;
+
+function buildPrompt(
+  message: string,
+  collectionId: string,
+  history: AgentConversationMessage[]
+): string {
+  const sections: string[] = [
+    `Active collection ID: ${collectionId}`,
+    'When you need additional context, call the `search_rag` tool to retrieve relevant chunks before answering.',
+  ];
+
+  if (history.length > 0) {
+    const formattedHistory = history
+      .map((entry) => `${entry.role === 'assistant' ? 'Assistant' : 'User'}: ${entry.content}`)
+      .join('\n');
+    sections.push(`Conversation so far:\n${formattedHistory}`);
+  }
+
+  sections.push(`Current user message:\n${message}`);
+  return sections.join('\n\n');
+}
+
+function extractTextFromContent(content: ContentBlock[]): string {
+  const textParts: string[] = [];
+  for (const block of content) {
+    if (block.type === 'text') {
+      textParts.push(block.text);
+    }
+  }
+  return textParts.join('\n').trim();
+}
+
+function convertHistoryToMessages(history: AgentConversationMessage[]): MessageParam[] {
+  return history.map((msg) => ({
+    role: msg.role,
+    content: msg.content,
+  }));
+}
+
+export async function runAgentChat(db: Pool, params: AgentChatParams): Promise<AgentChatResult> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new Error('ANTHROPIC_API_KEY environment variable must be set to use the agent.');
+  }
+
+  const anthropic = new Anthropic({
+    apiKey: process.env.ANTHROPIC_API_KEY,
+  });
+
+  const history = params.history ?? [];
+  const { tools: toolDefinitions, toolExecutors } = buildAgentTools(db, {
+    collectionId: params.collectionId,
+  });
+
+  const systemPrompt = `${BASE_SYSTEM_PROMPT}\n\nActive collection ID: ${params.collectionId}`;
+  const messages: MessageParam[] = [
+    ...convertHistoryToMessages(history),
+    { role: 'user', content: buildPrompt(params.message, params.collectionId, history) },
+  ];
+
+  const toolCalls: AgentToolCall[] = [];
+  let assistantMessage = '';
+  let totalUsage: Record<string, unknown> = {};
+
+  const maxTurns = 10;
+  let turn = 0;
+
+  while (turn < maxTurns) {
+    turn++;
+
+    const response = await anthropic.messages.create({
+      model: 'claude-3-7-sonnet-20250219',
+      max_tokens: 4096,
+      system: systemPrompt,
+      messages,
+      tools: toolDefinitions as Tool[],
+    });
+
+    // Accumulate usage
+    if (response.usage) {
+      totalUsage = {
+        input_tokens:
+          ((totalUsage.input_tokens as number) ?? 0) + (response.usage.input_tokens ?? 0),
+        output_tokens:
+          ((totalUsage.output_tokens as number) ?? 0) + (response.usage.output_tokens ?? 0),
+      };
+    }
+
+    // Extract text content
+    const textContent = extractTextFromContent(response.content);
+    if (textContent) {
+      assistantMessage = textContent;
+    }
+
+    // Check for tool uses
+    const toolUseBlocks = response.content.filter((block) => block.type === 'tool_use');
+
+    if (toolUseBlocks.length === 0) {
+      // No tools called, conversation is complete
+      break;
+    }
+
+    // Add assistant's response with tool calls to messages
+    messages.push({
+      role: 'assistant',
+      content: response.content,
+    });
+
+    // Execute tools and collect results
+    const toolResults: Array<{
+      type: 'tool_result';
+      tool_use_id: string;
+      content: string;
+      is_error?: boolean;
+    }> = [];
+
+    for (const toolUse of toolUseBlocks) {
+      if (toolUse.type !== 'tool_use') continue;
+
+      const toolCall: AgentToolCall = {
+        id: toolUse.id,
+        tool: toolUse.name,
+        input: toolUse.input,
+        status: 'started',
+      };
+
+      toolCalls.push(toolCall);
+
+      try {
+        const executor = toolExecutors[toolUse.name];
+        if (!executor) {
+          throw new Error(`Tool ${toolUse.name} not found`);
+        }
+
+        const result = await executor(toolUse.input);
+        const resultText = extractToolResultContent(result);
+
+        toolCall.status = 'completed';
+        toolCall.result = resultText;
+
+        toolResults.push({
+          type: 'tool_result',
+          tool_use_id: toolUse.id,
+          content: resultText,
+        });
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        toolCall.status = 'error';
+        toolCall.result = errorMessage;
+
+        toolResults.push({
+          type: 'tool_result',
+          tool_use_id: toolUse.id,
+          content: errorMessage,
+          is_error: true,
+        });
+      }
+    }
+
+    // Add tool results to messages
+    messages.push({
+      role: 'user',
+      content: toolResults,
+    });
+
+    // If this was the last turn, get one more response from Claude
+    if (turn === maxTurns) {
+      const finalResponse = await anthropic.messages.create({
+        model: 'claude-3-7-sonnet-20250219',
+        max_tokens: 4096,
+        system: systemPrompt,
+        messages,
+        tools: toolDefinitions as Tool[],
+      });
+
+      if (finalResponse.usage) {
+        totalUsage = {
+          input_tokens:
+            ((totalUsage.input_tokens as number) ?? 0) + (finalResponse.usage.input_tokens ?? 0),
+          output_tokens:
+            ((totalUsage.output_tokens as number) ?? 0) + (finalResponse.usage.output_tokens ?? 0),
+        };
+      }
+
+      const finalText = extractTextFromContent(finalResponse.content);
+      if (finalText) {
+        assistantMessage = finalText;
+      }
+      break;
+    }
+  }
+
+  const updatedHistory: AgentConversationMessage[] = [
+    ...history,
+    { role: 'user', content: params.message },
+    { role: 'assistant', content: assistantMessage },
+  ];
+
+  return {
+    message: assistantMessage,
+    toolCalls,
+    history: updatedHistory,
+    usage: totalUsage,
+  };
+}
+
+function extractToolResultContent(result: string | { content?: unknown }): string {
+  if (typeof result === 'string') {
+    return result;
+  }
+
+  if (result && typeof result === 'object') {
+    if (result.content && Array.isArray(result.content)) {
+      const textParts: string[] = [];
+      for (const block of result.content) {
+        if (
+          block &&
+          typeof block === 'object' &&
+          block.type === 'text' &&
+          typeof block.text === 'string'
+        ) {
+          textParts.push(block.text);
+        }
+      }
+      const combined = textParts.join('\n').trim();
+      if (combined) {
+        return combined;
+      }
+    }
+
+    // Fallback to JSON stringify
+    return JSON.stringify(result, null, 2);
+  }
+
+  return String(result);
+}

--- a/apps/server/src/agent/tools.ts
+++ b/apps/server/src/agent/tools.ts
@@ -1,0 +1,775 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { Tool } from '@anthropic-ai/sdk/resources/messages.js';
+import {
+  createDocument,
+  deleteDocumentChunks,
+  getDocument,
+  getDocumentChunks,
+} from '@synthesis/db';
+import type { Pool } from 'pg';
+import { chromium } from 'playwright';
+import { z } from 'zod';
+import { ingestDocument } from '../pipeline/orchestrator.js';
+import { searchCollection } from '../services/search.js';
+import {
+  type RemoteDownloadResult,
+  deleteFileIfExists,
+  downloadRemoteFile,
+  inferContentType,
+  inferExtension,
+  inferTitle,
+  isUrl,
+  readLocalFile,
+  writeDocumentFile,
+} from './utils/storage.js';
+
+const SEARCH_TOOL_NAME = 'search_rag';
+const ADD_DOCUMENT_TOOL_NAME = 'add_document';
+const FETCH_WEB_CONTENT_TOOL_NAME = 'fetch_web_content';
+const LIST_COLLECTIONS_TOOL_NAME = 'list_collections';
+const LIST_DOCUMENTS_TOOL_NAME = 'list_documents';
+const GET_DOCUMENT_STATUS_TOOL_NAME = 'get_document_status';
+const DELETE_DOCUMENT_TOOL_NAME = 'delete_document';
+const RESTART_INGEST_TOOL_NAME = 'restart_ingest';
+const SUMMARIZE_DOCUMENT_TOOL_NAME = 'summarize_document';
+
+export interface ToolContext {
+  collectionId: string;
+}
+
+type ToolExecutor = (input: unknown) => Promise<string>;
+
+function createToolResponse(message: string, payload?: unknown): string {
+  const text = payload ? `${message}\n\n${JSON.stringify(payload, null, 2)}` : message;
+  return text;
+}
+
+type JsonSchema =
+  | { type: 'string'; enum?: string[]; default?: unknown }
+  | { type: 'number'; default?: unknown }
+  | { type: 'boolean'; default?: unknown }
+  | {
+      type: 'object';
+      properties: Record<string, JsonSchema>;
+      required?: string[];
+      default?: unknown;
+    };
+
+function zodToJsonSchema(schema: z.ZodTypeAny): JsonSchema {
+  if (schema instanceof z.ZodString) {
+    return { type: 'string' };
+  }
+  if (schema instanceof z.ZodNumber) {
+    return { type: 'number' };
+  }
+  if (schema instanceof z.ZodBoolean) {
+    return { type: 'boolean' };
+  }
+  if (schema instanceof z.ZodDefault) {
+    return zodToJsonSchema(schema._def.innerType);
+  }
+  if (schema instanceof z.ZodOptional) {
+    return zodToJsonSchema(schema._def.innerType);
+  }
+  if (schema instanceof z.ZodObject) {
+    const shape = schema._def.shape();
+    const properties: Record<string, JsonSchema> = {};
+    const required: string[] = [];
+
+    for (const [key, value] of Object.entries(shape)) {
+      properties[key] = zodToJsonSchema(value as z.ZodTypeAny);
+      if (!(value instanceof z.ZodOptional) && !(value instanceof z.ZodDefault)) {
+        required.push(key);
+      }
+    }
+
+    return {
+      type: 'object',
+      properties,
+      ...(required.length > 0 ? { required } : {}),
+    };
+  }
+  if (schema instanceof z.ZodEnum) {
+    return { type: 'string', enum: schema._def.values };
+  }
+  if (schema instanceof z.ZodRecord) {
+    return { type: 'object', properties: {} };
+  }
+  return { type: 'string' };
+}
+
+export function createSearchRagTool(
+  db: Pool,
+  context: ToolContext
+): {
+  definition: Tool;
+  executor: ToolExecutor;
+} {
+  const inputSchema = z.object({
+    query: z.string().min(1, 'query must not be empty'),
+    collection_id: z.string().uuid().optional().default(context.collectionId),
+    top_k: z.number().int().min(1).max(50).optional().default(5),
+    min_similarity: z.number().min(0).max(1).optional().default(0.5),
+  });
+
+  return {
+    definition: {
+      name: SEARCH_TOOL_NAME,
+      description:
+        'Search the RAG knowledge base for relevant information and return matching chunks with citations.',
+      input_schema: zodToJsonSchema(inputSchema) as Tool['input_schema'],
+    },
+    executor: async (args: unknown) => {
+      const parsed = inputSchema.parse(args);
+      const searchResult = await searchCollection(db, {
+        query: parsed.query,
+        collectionId: parsed.collection_id ?? context.collectionId,
+        topK: parsed.top_k ?? 5,
+        minSimilarity: parsed.min_similarity ?? 0.5,
+      });
+
+      const payload = {
+        query: searchResult.query,
+        results: searchResult.results,
+        total_results: searchResult.totalResults,
+        search_time_ms: searchResult.searchTimeMs,
+      };
+
+      return createToolResponse(
+        `Vector search completed for "${payload.query}". Returning ${payload.total_results} result(s).`,
+        payload
+      );
+    },
+  };
+}
+
+export function createAddDocumentTool(
+  db: Pool,
+  context: ToolContext
+): {
+  definition: Tool;
+  executor: ToolExecutor;
+} {
+  const inputSchema = z.object({
+    source: z.string().min(1, 'source must not be empty'),
+    collection_id: z.string().uuid().optional().default(context.collectionId),
+    title: z.string().min(1).optional(),
+    metadata: z.record(z.any()).optional(),
+  });
+
+  return {
+    definition: {
+      name: ADD_DOCUMENT_TOOL_NAME,
+      description:
+        'Add a document to the RAG system from a file path or URL and trigger ingestion.',
+      input_schema: zodToJsonSchema(inputSchema) as Tool['input_schema'],
+    },
+    executor: async (args: unknown) => {
+      const parsed = inputSchema.parse(args);
+      const collectionId = parsed.collection_id ?? context.collectionId;
+      const source = parsed.source.trim();
+      const metadata = parsed.metadata ?? {};
+
+      const remote = isUrl(source);
+      const download = remote ? await downloadRemoteFile(source) : await readLocalFile(source);
+      const remoteDownload = remote ? (download as RemoteDownloadResult) : null;
+
+      const referenceName = remoteDownload?.fileName ?? source;
+      const contentType = inferContentType(
+        referenceName,
+        remoteDownload?.contentType ?? download.contentType
+      );
+      const extension = inferExtension(contentType, referenceName);
+      const title = parsed.title?.trim()?.length ? parsed.title.trim() : inferTitle(referenceName);
+
+      const document = await createDocument({
+        collection_id: collectionId,
+        title,
+        file_path: undefined,
+        content_type: contentType,
+        file_size: download.buffer.length,
+        source_url: remote ? source : undefined,
+      });
+
+      if (Object.keys(metadata).length > 0) {
+        await db.query('UPDATE documents SET metadata = $1 WHERE id = $2', [metadata, document.id]);
+      }
+
+      const filePath = await writeDocumentFile(
+        collectionId,
+        document.id,
+        extension,
+        download.buffer
+      );
+      await updateDocumentStatusSafe(db, document.id, 'pending', undefined, filePath);
+
+      ingestDocument(document.id).catch((error: unknown) => {
+        console.error(`Ingestion failed for ${document.id}`, error);
+      });
+
+      return createToolResponse('Document queued for ingestion.', {
+        doc_id: document.id,
+        title,
+        collection_id: collectionId,
+        content_type: contentType,
+        file_path: filePath,
+        metadata,
+      });
+    },
+  };
+}
+
+export function createFetchWebContentTool(
+  db: Pool,
+  context: ToolContext
+): {
+  definition: Tool;
+  executor: ToolExecutor;
+} {
+  const inputSchema = z.object({
+    url: z.string().url(),
+    collection_id: z.string().uuid().optional().default(context.collectionId),
+    mode: z.enum(['single', 'crawl']).optional().default('single'),
+    max_pages: z.number().int().min(1).max(200).optional().default(25),
+    title_prefix: z.string().min(1).optional(),
+  });
+
+  return {
+    definition: {
+      name: FETCH_WEB_CONTENT_TOOL_NAME,
+      description:
+        'Fetch web content (single page or crawl) and ingest it into the active collection.',
+      input_schema: zodToJsonSchema(inputSchema) as Tool['input_schema'],
+    },
+    executor: async (args: unknown) => {
+      const parsed = inputSchema.parse(args);
+      const collectionId = parsed.collection_id ?? context.collectionId;
+      const queue = [parsed.url];
+      const visited = new Set<string>();
+      const processed: Array<{ docId: string; url: string; title: string }> = [];
+
+      const browser = await chromium.launch({ headless: true });
+      try {
+        const page = await browser.newPage();
+
+        while (queue.length > 0 && processed.length < parsed.max_pages) {
+          const nextUrl = queue.shift();
+          if (!nextUrl) {
+            break;
+          }
+          if (visited.has(nextUrl)) {
+            continue;
+          }
+
+          visited.add(nextUrl);
+          try {
+            await page.goto(nextUrl, { waitUntil: 'networkidle', timeout: 30_000 });
+          } catch (navigationError) {
+            console.warn(`Failed to load ${nextUrl}`, navigationError);
+            continue;
+          }
+
+          const title = await page.title();
+          const bodyText = await page.evaluate(() => {
+            type TextNode = { innerText?: string } | null | undefined;
+            type DocumentLike = {
+              querySelector?: (selector: string) => TextNode;
+              body?: TextNode;
+              documentElement?: TextNode;
+            };
+            const doc = (globalThis as { document?: DocumentLike }).document;
+            const main =
+              doc?.querySelector?.('main, article, .content, #content') ??
+              doc?.body ??
+              doc?.documentElement;
+            const text = main?.innerText;
+            return typeof text === 'string' ? text : '';
+          });
+
+          if (!bodyText.trim()) {
+            console.warn(`No content extracted from ${nextUrl}`);
+            continue;
+          }
+
+          const cleanedTitle = parsed.title_prefix
+            ? `${parsed.title_prefix} - ${title || inferTitle(nextUrl)}`
+            : title || inferTitle(nextUrl);
+
+          const buffer = Buffer.from(bodyText.trim(), 'utf-8');
+          const document = await createDocument({
+            collection_id: collectionId,
+            title: cleanedTitle,
+            file_path: undefined,
+            content_type: 'text/markdown',
+            file_size: buffer.length,
+            source_url: nextUrl,
+          });
+
+          const filePath = await writeDocumentFile(collectionId, document.id, '.md', buffer);
+          await updateDocumentStatusSafe(db, document.id, 'pending', undefined, filePath);
+
+          ingestDocument(document.id).catch((error: unknown) => {
+            console.error(`Ingestion failed for ${document.id}`, error);
+          });
+
+          processed.push({ docId: document.id, url: nextUrl, title: cleanedTitle });
+
+          if (parsed.mode === 'crawl') {
+            const discovered = await page.$$eval(
+              'a[href]',
+              (anchors, origin) => {
+                const baseUrl = new URL(origin);
+                const originHost = baseUrl.origin;
+
+                return anchors
+                  .map((anchor) => {
+                    try {
+                      type AnchorLike = {
+                        href?: string;
+                        getAttribute?: (attr: string) => string | null;
+                      };
+                      const node = anchor as AnchorLike;
+                      const candidate: string | null =
+                        typeof node.href === 'string'
+                          ? node.href
+                          : typeof node.getAttribute === 'function'
+                            ? node.getAttribute('href')
+                            : null;
+
+                      if (!candidate) {
+                        return null;
+                      }
+
+                      return new URL(candidate, origin).href;
+                    } catch {
+                      return null;
+                    }
+                  })
+                  .filter((href): href is string => typeof href === 'string')
+                  .filter((href) => href.startsWith(originHost) && !href.includes('#'));
+              },
+              nextUrl
+            );
+
+            for (const link of discovered) {
+              if (!visited.has(link) && !queue.includes(link)) {
+                queue.push(link);
+              }
+            }
+          }
+        }
+      } finally {
+        await browser.close();
+      }
+
+      return createToolResponse(
+        `Fetched and queued ${processed.length} page(s) for ingestion.`,
+        processed
+      );
+    },
+  };
+}
+
+export function createListCollectionsTool(db: Pool): { definition: Tool; executor: ToolExecutor } {
+  return {
+    definition: {
+      name: LIST_COLLECTIONS_TOOL_NAME,
+      description: 'List available collections with document counts.',
+      input_schema: {
+        type: 'object',
+        properties: {},
+      },
+    },
+    executor: async () => {
+      const { rows } = await db.query<{
+        id: string;
+        name: string;
+        description: string | null;
+        doc_count: string;
+        created_at: Date;
+      }>(`
+        SELECT
+          c.id,
+          c.name,
+          c.description,
+          COUNT(d.id)::text AS doc_count,
+          c.created_at
+        FROM collections c
+        LEFT JOIN documents d ON d.collection_id = c.id
+        GROUP BY c.id
+        ORDER BY c.created_at DESC
+      `);
+
+      const collections = rows.map((row) => ({
+        id: row.id,
+        name: row.name,
+        description: row.description,
+        doc_count: Number(row.doc_count),
+        created_at: row.created_at,
+      }));
+
+      return createToolResponse('Collections retrieved.', { collections });
+    },
+  };
+}
+
+export function createListDocumentsTool(
+  db: Pool,
+  context: ToolContext
+): {
+  definition: Tool;
+  executor: ToolExecutor;
+} {
+  const inputSchema = z.object({
+    collection_id: z.string().uuid().optional().default(context.collectionId),
+    status: z
+      .enum(['pending', 'extracting', 'chunking', 'embedding', 'complete', 'error', 'all'])
+      .optional()
+      .default('all'),
+    limit: z.number().int().min(1).max(200).optional().default(50),
+  });
+
+  return {
+    definition: {
+      name: LIST_DOCUMENTS_TOOL_NAME,
+      description: 'List documents in a collection with status information.',
+      input_schema: zodToJsonSchema(inputSchema) as Tool['input_schema'],
+    },
+    executor: async (args: unknown) => {
+      const parsed = inputSchema.parse(args);
+      const collectionId = parsed.collection_id ?? context.collectionId;
+      const params: Array<string | number> = [collectionId];
+      let paramIndex = 2;
+
+      let statusFilter = '';
+      if (parsed.status && parsed.status !== 'all') {
+        statusFilter = `AND d.status = $${paramIndex++}`;
+        params.push(parsed.status);
+      }
+
+      params.push(parsed.limit);
+
+      const { rows } = await db.query<{
+        id: string;
+        title: string;
+        status: string;
+        file_size: number | null;
+        source_url: string | null;
+        created_at: Date;
+        updated_at: Date;
+        chunk_count: string;
+        token_count: string | null;
+      }>(
+        `
+        SELECT
+          d.id,
+          d.title,
+          d.status,
+          d.file_size,
+          d.source_url,
+          d.created_at,
+          d.updated_at,
+          COUNT(ch.id)::text AS chunk_count,
+          SUM(ch.token_count)::text AS token_count
+        FROM documents d
+        LEFT JOIN chunks ch ON ch.doc_id = d.id
+        WHERE d.collection_id = $1
+        ${statusFilter}
+        GROUP BY d.id
+        ORDER BY d.created_at DESC
+        LIMIT $${paramIndex}
+      `,
+        params
+      );
+
+      const documents = rows.map((row) => ({
+        id: row.id,
+        title: row.title,
+        status: row.status,
+        file_size: row.file_size,
+        source_url: row.source_url,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+        chunk_count: Number(row.chunk_count),
+        token_count: row.token_count ? Number(row.token_count) : null,
+      }));
+
+      return createToolResponse(`Retrieved ${documents.length} document(s).`, { documents });
+    },
+  };
+}
+
+export function createGetDocumentStatusTool(db: Pool): {
+  definition: Tool;
+  executor: ToolExecutor;
+} {
+  const inputSchema = z.object({
+    doc_id: z.string().uuid(),
+  });
+
+  return {
+    definition: {
+      name: GET_DOCUMENT_STATUS_TOOL_NAME,
+      description: 'Check the processing status of a document.',
+      input_schema: zodToJsonSchema(inputSchema) as Tool['input_schema'],
+    },
+    executor: async (args: unknown) => {
+      const parsed = inputSchema.parse(args);
+      const { rows } = await db.query<{
+        id: string;
+        title: string;
+        status: string;
+        error_message: string | null;
+        created_at: Date;
+        processed_at: Date | null;
+        file_path: string | null;
+        chunk_count: string;
+        total_tokens: string | null;
+      }>(
+        `
+        SELECT
+          d.id,
+          d.title,
+          d.status,
+          d.error_message,
+          d.created_at,
+          d.processed_at,
+          d.file_path,
+          COUNT(ch.id)::text AS chunk_count,
+          SUM(ch.token_count)::text AS total_tokens
+        FROM documents d
+        LEFT JOIN chunks ch ON ch.doc_id = d.id
+        WHERE d.id = $1
+        GROUP BY d.id
+      `,
+        [parsed.doc_id]
+      );
+
+      if (rows.length === 0) {
+        return createToolResponse(`Document ${parsed.doc_id} not found.`);
+      }
+
+      const doc = rows[0];
+      const payload = {
+        doc_id: doc.id,
+        title: doc.title,
+        status: doc.status,
+        error: doc.error_message,
+        created_at: doc.created_at,
+        processed_at: doc.processed_at,
+        chunk_count: Number(doc.chunk_count),
+        total_tokens: doc.total_tokens ? Number(doc.total_tokens) : null,
+        file_path: doc.file_path,
+      };
+
+      return createToolResponse(`Status retrieved for document ${doc.title}.`, payload);
+    },
+  };
+}
+
+export function createDeleteDocumentTool(db: Pool): { definition: Tool; executor: ToolExecutor } {
+  const inputSchema = z.object({
+    doc_id: z.string().uuid(),
+    confirm: z.boolean().optional().default(false),
+  });
+
+  return {
+    definition: {
+      name: DELETE_DOCUMENT_TOOL_NAME,
+      description: 'Delete a document and all associated chunks (requires confirm=true).',
+      input_schema: zodToJsonSchema(inputSchema) as Tool['input_schema'],
+    },
+    executor: async (args: unknown) => {
+      const parsed = inputSchema.parse(args);
+      if (!parsed.confirm) {
+        return createToolResponse(
+          'Deletion not confirmed. Set confirm=true to permanently remove the document.'
+        );
+      }
+
+      const document = await getDocument(parsed.doc_id);
+      if (!document) {
+        return createToolResponse(`Document ${parsed.doc_id} not found.`);
+      }
+
+      await deleteDocumentChunks(document.id);
+      await db.query('DELETE FROM documents WHERE id = $1', [document.id]);
+      await deleteFileIfExists(document.file_path);
+
+      return createToolResponse(`Document ${document.title} deleted.`, {
+        doc_id: document.id,
+        title: document.title,
+      });
+    },
+  };
+}
+
+export function createRestartIngestTool(db: Pool): { definition: Tool; executor: ToolExecutor } {
+  const inputSchema = z.object({
+    doc_id: z.string().uuid(),
+  });
+
+  return {
+    definition: {
+      name: RESTART_INGEST_TOOL_NAME,
+      description: 'Retry ingestion for a document that previously failed or is stuck.',
+      input_schema: zodToJsonSchema(inputSchema) as Tool['input_schema'],
+    },
+    executor: async (args: unknown) => {
+      const parsed = inputSchema.parse(args);
+      const document = await getDocument(parsed.doc_id);
+      if (!document) {
+        return createToolResponse(`Document ${parsed.doc_id} not found.`);
+      }
+
+      if (!document.file_path) {
+        return createToolResponse(`Document ${document.id} has no stored file to ingest.`);
+      }
+
+      await db.query(
+        `UPDATE documents
+         SET status = 'pending',
+             error_message = NULL,
+             processed_at = NULL,
+             updated_at = NOW()
+         WHERE id = $1`,
+        [document.id]
+      );
+
+      ingestDocument(document.id).catch((error: unknown) => {
+        console.error(`Re-ingestion failed for ${document.id}`, error);
+      });
+
+      return createToolResponse(`Re-ingestion started for document ${document.title}.`);
+    },
+  };
+}
+
+export function createSummarizeDocumentTool(_db: Pool): {
+  definition: Tool;
+  executor: ToolExecutor;
+} {
+  const inputSchema = z.object({
+    doc_id: z.string().uuid(),
+    max_chunks: z.number().int().min(1).max(25).optional().default(10),
+  });
+
+  return {
+    definition: {
+      name: SUMMARIZE_DOCUMENT_TOOL_NAME,
+      description: 'Summarize a document using Claude based on its stored chunks.',
+      input_schema: zodToJsonSchema(inputSchema) as Tool['input_schema'],
+    },
+    executor: async (args: unknown) => {
+      const parsed = inputSchema.parse(args);
+      if (!process.env.ANTHROPIC_API_KEY) {
+        throw new Error('ANTHROPIC_API_KEY environment variable must be set for summarization.');
+      }
+
+      const document = await getDocument(parsed.doc_id);
+      if (!document) {
+        return createToolResponse(`Document ${parsed.doc_id} not found.`);
+      }
+
+      const chunks = await getDocumentChunks(document.id);
+      if (chunks.length === 0) {
+        return createToolResponse(`Document ${document.title} has no chunks to summarize.`);
+      }
+
+      const selectedChunks = chunks.slice(0, parsed.max_chunks);
+      const combinedText = selectedChunks.map((chunk) => chunk.text).join('\n\n');
+
+      const client = new Anthropic({
+        apiKey: process.env.ANTHROPIC_API_KEY,
+      });
+
+      const response = await client.messages.create({
+        model: 'claude-3-5-sonnet-20241022',
+        max_tokens: 512,
+        system:
+          'You are a documentation assistant that summarizes technical documents concisely with key points and citations when possible.',
+        messages: [
+          {
+            role: 'user',
+            content: `Summarize the following document titled "${document.title}". Highlight the main points and include section references if provided.\n\n${combinedText}`,
+          },
+        ],
+      });
+
+      const summary = extractTextContent(response);
+
+      return createToolResponse(`Summary generated for document ${document.title}.`, {
+        doc_id: document.id,
+        title: document.title,
+        summary,
+      });
+    },
+  };
+}
+
+function extractTextContent(
+  response: Awaited<ReturnType<Anthropic['messages']['create']>>
+): string {
+  if (!('content' in response) || !Array.isArray(response.content)) {
+    return '';
+  }
+  const textParts: string[] = [];
+  const blocks = response.content;
+  for (const block of blocks) {
+    if (
+      block &&
+      typeof block === 'object' &&
+      block.type === 'text' &&
+      typeof block.text === 'string'
+    ) {
+      textParts.push(block.text);
+    }
+  }
+  return textParts.join('\n').trim();
+}
+
+async function updateDocumentStatusSafe(
+  db: Pool,
+  documentId: string,
+  status: string,
+  errorMessage?: string,
+  filePath?: string
+): Promise<void> {
+  await db.query(
+    `UPDATE documents
+     SET status = $1,
+         error_message = $2,
+         updated_at = NOW(),
+         processed_at = CASE WHEN $1 = 'complete' THEN NOW() ELSE processed_at END,
+         file_path = COALESCE($3, file_path)
+     WHERE id = $4`,
+    [status, errorMessage ?? null, filePath ?? null, documentId]
+  );
+}
+
+export function buildAgentTools(
+  db: Pool,
+  context: ToolContext
+): { tools: Tool[]; toolExecutors: Record<string, ToolExecutor> } {
+  const toolBuilders = [
+    createSearchRagTool(db, context),
+    createAddDocumentTool(db, context),
+    createFetchWebContentTool(db, context),
+    createListCollectionsTool(db),
+    createListDocumentsTool(db, context),
+    createGetDocumentStatusTool(db),
+    createDeleteDocumentTool(db),
+    createRestartIngestTool(db),
+    createSummarizeDocumentTool(db),
+  ];
+
+  const tools: Tool[] = [];
+  const toolExecutors: Record<string, ToolExecutor> = {};
+
+  for (const builder of toolBuilders) {
+    tools.push(builder.definition);
+    toolExecutors[builder.definition.name] = builder.executor;
+  }
+
+  return { tools, toolExecutors };
+}

--- a/apps/server/src/agent/utils/storage.ts
+++ b/apps/server/src/agent/utils/storage.ts
@@ -1,0 +1,249 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const STORAGE_ROOT = process.env.STORAGE_PATH || './storage';
+
+const EXTENSION_TO_MIME: Record<string, string> = {
+  '.pdf': 'application/pdf',
+  '.doc': 'application/msword',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.md': 'text/markdown',
+  '.markdown': 'text/markdown',
+  '.txt': 'text/plain',
+  '.html': 'text/html',
+  '.htm': 'text/html',
+  '.json': 'application/json',
+  '.csv': 'text/csv',
+};
+
+// Build MIME_TO_EXTENSION with preference for more common extensions
+const MIME_TO_EXTENSION: Record<string, string> = {};
+const PREFERRED_EXTENSIONS: Record<string, string> = {
+  'text/html': '.html',
+  'text/markdown': '.md',
+};
+
+for (const [ext, mime] of Object.entries(EXTENSION_TO_MIME)) {
+  // If there's a preferred extension for this MIME type, use it
+  if (PREFERRED_EXTENSIONS[mime]) {
+    MIME_TO_EXTENSION[mime] = PREFERRED_EXTENSIONS[mime];
+  } else if (!MIME_TO_EXTENSION[mime]) {
+    // Otherwise, use the first one we encounter or prefer shorter extensions
+    MIME_TO_EXTENSION[mime] = ext;
+  } else {
+    // Prefer shorter extension if current mapping is longer
+    if (ext.length < MIME_TO_EXTENSION[mime].length) {
+      MIME_TO_EXTENSION[mime] = ext;
+    }
+  }
+}
+
+export interface RemoteDownloadResult {
+  buffer: Buffer;
+  contentType?: string | null;
+  fileName?: string | null;
+}
+
+export function isUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export function inferContentType(source: string, explicit?: string | null): string {
+  const normalized = explicit?.split(';')[0]?.trim();
+  if (normalized) {
+    return normalized;
+  }
+
+  const extension = path.extname(source).toLowerCase();
+  if (extension && EXTENSION_TO_MIME[extension]) {
+    return EXTENSION_TO_MIME[extension];
+  }
+
+  return 'application/octet-stream';
+}
+
+export function inferExtension(contentType: string | null | undefined, source?: string): string {
+  if (contentType) {
+    const normalized = contentType.split(';')[0]?.trim();
+    if (normalized && MIME_TO_EXTENSION[normalized]) {
+      return MIME_TO_EXTENSION[normalized];
+    }
+  }
+
+  if (source) {
+    const ext = path.extname(source);
+    if (ext) {
+      return ext;
+    }
+  }
+
+  return '.bin';
+}
+
+export function inferTitle(source: string): string {
+  if (isUrl(source)) {
+    try {
+      const url = new URL(source);
+      const segments = url.pathname.split('/').filter(Boolean);
+      const slug = segments.pop() || url.hostname;
+      return decodeURIComponent(slug.replace(/[-_]/g, ' ')).trim() || url.hostname;
+    } catch {
+      return source;
+    }
+  }
+
+  const base = path.basename(source);
+  return (
+    base
+      .replace(/\.[^.]+$/, '')
+      .replace(/[-_]/g, ' ')
+      .trim() || base
+  );
+}
+
+function validateId(id: string, name: string): void {
+  const SAFE_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+  if (!SAFE_ID_PATTERN.test(id)) {
+    throw new Error(
+      `Invalid ${name}: must contain only alphanumeric characters, underscores, and hyphens`
+    );
+  }
+}
+
+function validateExtension(extension: string): void {
+  if (!extension.startsWith('.')) {
+    throw new Error('Invalid extension: must start with a dot');
+  }
+  const SAFE_EXTENSION_PATTERN = /^\.[A-Za-z0-9]+$/;
+  if (!SAFE_EXTENSION_PATTERN.test(extension)) {
+    throw new Error('Invalid extension: must contain only alphanumeric characters after the dot');
+  }
+}
+
+export async function ensureCollectionDirectory(collectionId: string): Promise<string> {
+  validateId(collectionId, 'collectionId');
+  const dir = path.join(STORAGE_ROOT, collectionId);
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+export function resolveDocumentPath(
+  collectionId: string,
+  documentId: string,
+  extension: string
+): string {
+  validateId(collectionId, 'collectionId');
+  validateId(documentId, 'documentId');
+  validateExtension(extension);
+  return path.join(STORAGE_ROOT, collectionId, `${documentId}${extension}`);
+}
+
+export async function writeDocumentFile(
+  collectionId: string,
+  documentId: string,
+  extension: string,
+  buffer: Buffer
+): Promise<string> {
+  await ensureCollectionDirectory(collectionId);
+  const filePath = resolveDocumentPath(collectionId, documentId, extension);
+  await fs.writeFile(filePath, buffer);
+  return filePath;
+}
+
+export async function deleteFileIfExists(filePath: string | null | undefined): Promise<void> {
+  if (!filePath) {
+    return;
+  }
+
+  try {
+    await fs.unlink(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
+export async function downloadRemoteFile(url: string): Promise<RemoteDownloadResult> {
+  const TIMEOUT_MS = 30000; // 30 seconds
+  const MAX_BYTES = 50 * 1024 * 1024; // 50 MB
+
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(() => abortController.abort(), TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, { signal: abortController.signal });
+    if (!response.ok) {
+      throw new Error(`Failed to download ${url}: ${response.status} ${response.statusText}`);
+    }
+
+    if (!response.body) {
+      throw new Error('Response body is null');
+    }
+
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        totalBytes += value.length;
+        if (totalBytes > MAX_BYTES) {
+          abortController.abort();
+          throw new Error(`File size exceeds maximum allowed size of ${MAX_BYTES} bytes`);
+        }
+
+        chunks.push(value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    clearTimeout(timeoutId);
+
+    const buffer = Buffer.concat(chunks);
+    const contentType = response.headers.get('content-type');
+
+    let fileName: string | null = null;
+    const disposition = response.headers.get('content-disposition');
+    if (disposition) {
+      const match = disposition.match(/filename\*?=(?:UTF-8'')?\"?([^\";]+)/i);
+      if (match) {
+        fileName = decodeURIComponent(match[1]);
+      }
+    }
+
+    if (!fileName) {
+      try {
+        const parsed = new URL(url);
+        fileName = path.basename(parsed.pathname);
+      } catch {
+        fileName = null;
+      }
+    }
+
+    return { buffer, contentType, fileName };
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Download aborted: request exceeded ${TIMEOUT_MS}ms timeout or size limit`);
+    }
+    throw error;
+  }
+}
+
+export async function readLocalFile(
+  filePath: string
+): Promise<{ buffer: Buffer; contentType: string }> {
+  const buffer = await fs.readFile(filePath);
+  const contentType = inferContentType(filePath);
+  return { buffer, contentType };
+}

--- a/apps/server/src/pipeline/extract.ts
+++ b/apps/server/src/pipeline/extract.ts
@@ -37,11 +37,14 @@ export async function extractPDF(buffer: Buffer): Promise<ExtractionResult> {
   try {
     const data = (await pdf(buffer)) as unknown as PDFParseData;
 
+    const wordCount =
+      !data.text || data.text.trim() === '' ? 0 : data.text.trim().split(/\s+/).length;
+
     return {
       text: data.text,
       metadata: {
         pageCount: data.numpages,
-        wordCount: data.text.split(/\s+/).length,
+        wordCount,
       },
     };
   } catch (error) {
@@ -61,10 +64,13 @@ export async function extractDOCX(buffer: Buffer): Promise<ExtractionResult> {
   try {
     const result = await mammoth.extractRawText({ buffer });
 
+    const wordCount =
+      !result.value || result.value.trim() === '' ? 0 : result.value.trim().split(/\s+/).length;
+
     return {
       text: result.value,
       metadata: {
-        wordCount: result.value.split(/\s+/).length,
+        wordCount,
       },
     };
   } catch (error) {
@@ -88,10 +94,12 @@ export async function extractMarkdown(buffer: Buffer): Promise<ExtractionResult>
     const tree = processor.parse(text);
     const extracted = mdastToString(tree);
 
+    const wordCount = !text || text.trim() === '' ? 0 : text.trim().split(/\s+/).length;
+
     return {
       text: extracted || text, // Fallback to raw text if parsing fails
       metadata: {
-        wordCount: text.split(/\s+/).length,
+        wordCount,
       },
     };
   } catch (error) {
@@ -109,10 +117,12 @@ export async function extractMarkdown(buffer: Buffer): Promise<ExtractionResult>
 export function extractPlainText(buffer: Buffer): ExtractionResult {
   const text = buffer.toString('utf-8');
 
+  const wordCount = !text || text.trim() === '' ? 0 : text.trim().split(/\s+/).length;
+
   return {
     text,
     metadata: {
-      wordCount: text.split(/\s+/).length,
+      wordCount,
     },
   };
 }

--- a/apps/server/src/routes/__tests__/search.test.ts
+++ b/apps/server/src/routes/__tests__/search.test.ts
@@ -1,0 +1,85 @@
+import Fastify from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { searchRoutes } from '../search.js';
+
+vi.mock('../../services/search.js', () => ({
+  searchCollection: vi.fn(),
+}));
+
+vi.mock('@synthesis/db', () => ({
+  getPool: vi.fn(() => ({})),
+}));
+
+const { searchCollection } = await import('../../services/search.js');
+
+describe('POST /api/search route', () => {
+  let fastify: ReturnType<typeof Fastify>;
+
+  beforeEach(async () => {
+    fastify = Fastify();
+    await fastify.register(searchRoutes);
+    await fastify.ready();
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+    vi.clearAllMocks();
+  });
+
+  it('returns search results for a valid request', async () => {
+    (searchCollection as vi.Mock).mockResolvedValue({
+      query: 'test',
+      results: [
+        {
+          id: 1,
+          text: 'Example chunk',
+          similarity: 0.9,
+          docId: 'doc-1',
+          docTitle: 'Doc',
+          sourceUrl: null,
+          metadata: { page: 1 },
+          citation: { title: 'Doc', page: 1 },
+        },
+      ],
+      totalResults: 1,
+      searchTimeMs: 42,
+    });
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/api/search',
+      payload: {
+        query: 'test',
+        collection_id: '11111111-1111-4111-8111-111111111111',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.payload)).toMatchObject({
+      query: 'test',
+      total_results: 1,
+      search_time_ms: 42,
+      results: [
+        expect.objectContaining({
+          id: 1,
+          text: 'Example chunk',
+          doc_id: 'doc-1',
+          citation: { title: 'Doc', page: 1 },
+        }),
+      ],
+    });
+    expect(searchCollection).toHaveBeenCalled();
+  });
+
+  it('returns 400 when payload is invalid', async () => {
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/api/search',
+      payload: { collection_id: 'not-a-uuid' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.payload);
+    expect(body.error).toBe('INVALID_INPUT');
+  });
+});

--- a/apps/server/src/routes/agent.ts
+++ b/apps/server/src/routes/agent.ts
@@ -1,7 +1,6 @@
 import { getPool } from '@synthesis/db';
 import type { FastifyPluginAsync } from 'fastify';
 import { z } from 'zod';
-import type { AgentConversationMessage } from '../agent/agent.js';
 import { runAgentChat } from '../agent/agent.js';
 
 const ConversationMessageSchema = z
@@ -20,13 +19,6 @@ const AgentChatBodySchema = z
   .strict();
 
 type AgentChatBody = z.infer<typeof AgentChatBodySchema>;
-
-function mapHistory(history: AgentConversationMessage[]) {
-  return history.map((item) => ({
-    role: item.role,
-    content: item.content,
-  }));
-}
 
 export const agentRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.post('/api/agent/chat', async (request, reply) => {
@@ -58,7 +50,7 @@ export const agentRoutes: FastifyPluginAsync = async (fastify) => {
           result: call.result,
           server: call.serverName,
         })),
-        history: mapHistory(result.history),
+        history: result.history,
         usage: result.usage,
       });
     } catch (error) {

--- a/apps/server/src/routes/agent.ts
+++ b/apps/server/src/routes/agent.ts
@@ -1,0 +1,72 @@
+import { getPool } from '@synthesis/db';
+import type { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import type { AgentConversationMessage } from '../agent/agent.js';
+import { runAgentChat } from '../agent/agent.js';
+
+const ConversationMessageSchema = z
+  .object({
+    role: z.enum(['user', 'assistant']),
+    content: z.string().min(1),
+  })
+  .strict();
+
+const AgentChatBodySchema = z
+  .object({
+    message: z.string().min(1, 'message must not be empty'),
+    collection_id: z.string().uuid(),
+    history: z.array(ConversationMessageSchema).max(20).optional(),
+  })
+  .strict();
+
+type AgentChatBody = z.infer<typeof AgentChatBodySchema>;
+
+function mapHistory(history: AgentConversationMessage[]) {
+  return history.map((item) => ({
+    role: item.role,
+    content: item.content,
+  }));
+}
+
+export const agentRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post('/api/agent/chat', async (request, reply) => {
+    const validation = AgentChatBodySchema.safeParse(request.body);
+
+    if (!validation.success) {
+      return reply.code(400).send({
+        error: 'INVALID_INPUT',
+        details: validation.error.issues,
+      });
+    }
+
+    const body = validation.data as AgentChatBody;
+
+    try {
+      const result = await runAgentChat(getPool(), {
+        message: body.message,
+        collectionId: body.collection_id,
+        history: body.history ?? [],
+      });
+
+      return reply.send({
+        message: result.message,
+        tool_calls: result.toolCalls.map((call) => ({
+          id: call.id,
+          tool: call.tool,
+          status: call.status,
+          input: call.input,
+          result: call.result,
+          server: call.serverName,
+        })),
+        history: mapHistory(result.history),
+        usage: result.usage,
+      });
+    } catch (error) {
+      fastify.log.error(error, 'Agent chat failed');
+      return reply.code(500).send({
+        error: 'AGENT_ERROR',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  });
+};

--- a/apps/server/src/routes/search.ts
+++ b/apps/server/src/routes/search.ts
@@ -1,0 +1,64 @@
+import { getPool } from '@synthesis/db';
+import type { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import { searchCollection } from '../services/search.js';
+
+const SearchBodySchema = z
+  .object({
+    query: z.string().min(1, 'query must not be empty'),
+    collection_id: z.string().uuid(),
+    top_k: z.number().int().min(1).max(50).optional(),
+    min_similarity: z.number().min(0).max(1).optional(),
+  })
+  .strict();
+
+export const searchRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post('/api/search', async (request, reply) => {
+    const validation = SearchBodySchema.safeParse(request.body);
+
+    if (!validation.success) {
+      return reply.code(400).send({
+        error: 'INVALID_INPUT',
+        details: validation.error.issues,
+      });
+    }
+
+    const {
+      query,
+      collection_id: collectionId,
+      top_k: topK,
+      min_similarity: minSimilarity,
+    } = validation.data;
+
+    try {
+      const result = await searchCollection(getPool(), {
+        query,
+        collectionId,
+        topK,
+        minSimilarity,
+      });
+
+      return reply.send({
+        query: result.query,
+        results: result.results.map((item) => ({
+          id: item.id,
+          text: item.text,
+          similarity: item.similarity,
+          doc_id: item.docId,
+          doc_title: item.docTitle,
+          source_url: item.sourceUrl,
+          citation: item.citation,
+          metadata: item.metadata,
+        })),
+        total_results: result.totalResults,
+        search_time_ms: result.searchTimeMs,
+      });
+    } catch (error) {
+      fastify.log.error({ error }, 'Vector search failed');
+      return reply.code(500).send({
+        error: 'SEARCH_ERROR',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  });
+};

--- a/apps/server/src/services/__tests__/search.test.ts
+++ b/apps/server/src/services/__tests__/search.test.ts
@@ -1,0 +1,90 @@
+import type { Pool, QueryResult } from 'pg';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { searchCollection } from '../search.js';
+
+vi.mock('../../pipeline/embed.js', () => ({
+  embedText: vi.fn(),
+}));
+
+const { embedText } = await import('../../pipeline/embed.js');
+
+describe('searchCollection', () => {
+  let db: Pick<Pool, 'query'>;
+  let performanceSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    db = {
+      query: vi.fn(),
+    } as unknown as Pick<Pool, 'query'>;
+
+    performanceSpy = vi.spyOn(performance, 'now').mockReturnValueOnce(100).mockReturnValueOnce(160);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    performanceSpy.mockRestore();
+  });
+
+  it('embeds the query and returns formatted results', async () => {
+    (embedText as vi.MockedFunction<typeof embedText>).mockResolvedValue([0.1, 0.2, 0.3]);
+
+    const dbRows = [
+      {
+        id: 42,
+        text: 'Example chunk text',
+        metadata: { page: 3, heading: 'Overview' },
+        doc_id: 'doc-123',
+        doc_title: 'Sample Document',
+        source_url: 'https://example.com/doc',
+        similarity: 0.87,
+      },
+    ];
+
+    type SearchRow = (typeof dbRows)[number];
+    const queryResult = { rows: dbRows } as unknown as QueryResult<SearchRow>;
+
+    (db.query as vi.MockedFunction<Pool['query']>).mockResolvedValue(queryResult);
+
+    const result = await searchCollection(db as Pool, {
+      query: 'Test query',
+      collectionId: 'collection-1',
+      topK: 7,
+      minSimilarity: 0.4,
+    });
+
+    expect(embedText).toHaveBeenCalledWith('Test query');
+    expect(db.query).toHaveBeenCalledWith(expect.any(String), [
+      '[0.1,0.2,0.3]',
+      'collection-1',
+      0.4,
+      7,
+    ]);
+    expect(result.totalResults).toBe(1);
+    expect(result.searchTimeMs).toBe(60);
+    expect(result.results[0]).toMatchObject({
+      id: 42,
+      text: 'Example chunk text',
+      similarity: 0.87,
+      docId: 'doc-123',
+      docTitle: 'Sample Document',
+      sourceUrl: 'https://example.com/doc',
+      citation: {
+        title: 'Sample Document',
+        page: 3,
+        section: 'Overview',
+      },
+    });
+  });
+
+  it('throws when the query is empty after trimming', async () => {
+    await expect(
+      searchCollection(db as Pool, { query: '   ', collectionId: 'collection', topK: 5 })
+    ).rejects.toThrow(/must not be empty/i);
+  });
+
+  it('throws when topK is not positive', async () => {
+    await expect(
+      searchCollection(db as Pool, { query: 'hello', collectionId: 'collection', topK: 0 })
+    ).rejects.toThrow(/topK must be a positive number/);
+  });
+});

--- a/apps/server/src/services/search.ts
+++ b/apps/server/src/services/search.ts
@@ -19,8 +19,8 @@ export interface SearchResult {
   metadata: Record<string, unknown> | null;
   citation: {
     title: string | null;
-    page?: unknown;
-    section?: unknown;
+    page?: string | number | null;
+    section?: string | null;
   };
 }
 
@@ -84,6 +84,10 @@ export async function searchCollection(db: Pool, params: SearchParams): Promise<
 
   const results: SearchResult[] = rows.map((row) => {
     const metadata = (row.metadata ?? null) as Record<string, unknown> | null;
+    const rawPage = metadata?.page;
+    const page = typeof rawPage === 'number' || typeof rawPage === 'string' ? rawPage : null;
+    const rawSection = (metadata?.heading ?? metadata?.section) as unknown;
+    const section = typeof rawSection === 'string' ? rawSection : null;
 
     return {
       id: row.id as number,
@@ -95,8 +99,8 @@ export async function searchCollection(db: Pool, params: SearchParams): Promise<
       metadata,
       citation: {
         title: (row.doc_title as string | null) ?? null,
-        page: metadata?.page,
-        section: metadata?.heading,
+        page,
+        section,
       },
     };
   });

--- a/apps/server/src/services/search.ts
+++ b/apps/server/src/services/search.ts
@@ -1,0 +1,110 @@
+import { performance } from 'node:perf_hooks';
+import type { Pool } from 'pg';
+import { embedText } from '../pipeline/embed.js';
+
+export interface SearchParams {
+  query: string;
+  collectionId: string;
+  topK?: number;
+  minSimilarity?: number;
+}
+
+export interface SearchResult {
+  id: number;
+  text: string;
+  similarity: number;
+  docId: string;
+  docTitle: string | null;
+  sourceUrl: string | null;
+  metadata: Record<string, unknown> | null;
+  citation: {
+    title: string | null;
+    page?: unknown;
+    section?: unknown;
+  };
+}
+
+export interface SearchResponse {
+  query: string;
+  results: SearchResult[];
+  totalResults: number;
+  searchTimeMs: number;
+}
+
+const DEFAULT_TOP_K = 5;
+const DEFAULT_MIN_SIMILARITY = 0.5;
+
+function toVectorLiteral(vector: number[]): string {
+  if (!Array.isArray(vector) || vector.length === 0) {
+    throw new Error('Embedding vector must contain at least one value');
+  }
+
+  return `[${vector.join(',')}]`;
+}
+
+export async function searchCollection(db: Pool, params: SearchParams): Promise<SearchResponse> {
+  const topK = params.topK ?? DEFAULT_TOP_K;
+  const minSimilarity = params.minSimilarity ?? DEFAULT_MIN_SIMILARITY;
+
+  if (!Number.isFinite(topK) || topK <= 0) {
+    throw new Error('topK must be a positive number');
+  }
+
+  const trimmedQuery = params.query.trim();
+  if (trimmedQuery.length === 0) {
+    throw new Error('Query must not be empty');
+  }
+
+  const start = performance.now();
+  const embedding = await embedText(trimmedQuery);
+  const vectorLiteral = toVectorLiteral(embedding);
+
+  const { rows } = await db.query(
+    `
+      SELECT
+        ch.id,
+        ch.text,
+        ch.metadata,
+        ch.doc_id,
+        d.title AS doc_title,
+        d.source_url,
+        (1 - (ch.embedding <=> $1::vector)) AS similarity
+      FROM chunks ch
+      JOIN documents d ON d.id = ch.doc_id
+      WHERE d.collection_id = $2
+        AND ch.embedding IS NOT NULL
+        AND (1 - (ch.embedding <=> $1::vector)) >= $3
+      ORDER BY ch.embedding <=> $1::vector
+      LIMIT $4
+    `,
+    [vectorLiteral, params.collectionId, minSimilarity, topK]
+  );
+
+  const end = performance.now();
+
+  const results: SearchResult[] = rows.map((row) => {
+    const metadata = (row.metadata ?? null) as Record<string, unknown> | null;
+
+    return {
+      id: row.id as number,
+      text: row.text as string,
+      similarity: Number(row.similarity) || 0,
+      docId: row.doc_id as string,
+      docTitle: (row.doc_title as string | null) ?? null,
+      sourceUrl: (row.source_url as string | null) ?? null,
+      metadata,
+      citation: {
+        title: (row.doc_title as string | null) ?? null,
+        page: metadata?.page,
+        section: metadata?.heading,
+      },
+    };
+  });
+
+  return {
+    query: trimmedQuery,
+    results,
+    totalResults: results.length,
+    searchTimeMs: Math.round(end - start),
+  };
+}

--- a/docs/04_AGENT_TOOLS.md
+++ b/docs/04_AGENT_TOOLS.md
@@ -14,7 +14,7 @@ Define all tools the autonomous agent can use to manage your RAG system.
 
 ## 🤖 Agent Architecture
 
-**Key files**
+#### Key files
 - Conversation loop: `apps/server/src/agent/agent.ts`
 - Tool factories: `apps/server/src/agent/tools.ts`
 

--- a/docs/09_BUILD_PLAN.md
+++ b/docs/09_BUILD_PLAN.md
@@ -176,13 +176,11 @@ console.log(`Created ${chunks.rows[0].count} chunks`);
     -d '{"query": "test query", "collection_id": "uuid", "top_k": 5}'
   ```
 
-**Afternoon (4 hours):**
-- [ ] Install Agent SDK: `pnpm add @anthropic-ai/agent-sdk @anthropic-ai/sdk`
-
-- [ ] Create agent
-  - `apps/server/src/agent/agent.ts`
-  - Basic setup with system prompt
-  - Register `search_rag` tool
+- **Afternoon (4 hours):**
+- [ ] Wire up Claude Messages API loop
+  - Use `@anthropic-ai/sdk` directly (no `claude-agent-sdk` dependency)
+  - Implement manual tool-use loop in `apps/server/src/agent/agent.ts`
+  - Track token usage totals across turns
 
 - [ ] Implement `search_rag` tool
   - `apps/server/src/agent/tools/search.ts`

--- a/docs/14_GITHUB_ISSUES.md
+++ b/docs/14_GITHUB_ISSUES.md
@@ -351,18 +351,18 @@ gh issue create \
 
 # Story 3.2
 gh issue create \
-  --title "Setup Claude Agent SDK" \
+  --title "Implement Claude Messages API agent loop" \
   --label "phase-3,feature,priority:high" \
   --body "## Technical Specs
 - Documentation: docs/04_AGENT_TOOLS.md
-- Dependencies: @anthropic-ai/agent-sdk, @anthropic-ai/sdk
+- Dependencies: @anthropic-ai/sdk
 
 ## Tasks
-- [ ] Install Agent SDK
-- [ ] Create agent.ts
-- [ ] Configure system prompt
-- [ ] Register tools
-- [ ] Test basic agent response"
+- [ ] Implement manual tool-use loop in apps/server/src/agent/agent.ts
+- [ ] Build tool definitions/executors with buildAgentTools()
+- [ ] Track cumulative token usage and cap at 10 turns
+- [ ] Ensure `/api/agent/chat` executes tools and returns final response
+- [ ] Add unit tests covering the agent loop"
 
 # Story 3.3
 gh issue create \
@@ -374,10 +374,10 @@ gh issue create \
   - apps/server/src/agent/tools/search.ts
 
 ## Tasks
-- [ ] Define tool schema
-- [ ] Implement execute() function
-- [ ] Call search service
-- [ ] Format for agent
+- [ ] Define tool metadata/JSON schema via zodToJsonSchema
+- [ ] Implement executor that calls the vector search service and formats citations
+- [ ] Return definition/executor from createSearchRagTool()
+- [ ] Unit test tool execution
 - [ ] Register with agent
 - [ ] Test tool calling"
 

--- a/docs/15_AGENT_PROMPTS.md
+++ b/docs/15_AGENT_PROMPTS.md
@@ -275,7 +275,7 @@ apps/server/src/
 
 ```json
 {
-  "ollama": "^0.5.0"
+  "ollama": "^0.5.17"
 }
 ```
 
@@ -325,16 +325,15 @@ apps/server/src/routes/ingest.ts # Update to call the new orchestrator
     - Create a `POST /api/search` endpoint that takes a query and returns the search results from the service.
 
 3.  **Claude Agent Integration (`apps/server/src/agent/`)**
-    - Install and configure the `@anthropic-ai/claude-agent-sdk`.
-    - Define a `search_rag` tool that calls the vector search service.
-    - Create a `POST /api/agent/chat` endpoint that forwards the user's message to the agent and returns the response. The agent should automatically use the `search_rag` tool when needed.
+    - Use the `@anthropic-ai/sdk` Messages API directly (no `claude-agent-sdk`).
+    - Build `buildAgentTools()` so each tool exposes `{ definition, executor }`.
+    - Implement the manual tool loop in `POST /api/agent/chat`, executing local tools whenever Claude emits `tool_use` blocks.
 
 ## Dependencies to Install
 
 ```json
 {
-  "@anthropic-ai/claude-agent-sdk": "^0.1.7",
-  "@anthropic-ai/sdk": "^0.27.0"
+  "@anthropic-ai/sdk": "^0.65.0"
 }
 ```
 
@@ -391,7 +390,7 @@ apps/server/src/
 
 ```json
 {
-  "playwright": "^1.40.0"
+  "playwright": "^1.56.0"
 }
 ```
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
   apps/server:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.27.0
-        version: 0.27.3
+        specifier: ^0.65.0
+        version: 0.65.0(zod@3.25.76)
       '@fastify/cors':
         specifier: ^9.0.1
         version: 9.0.1
@@ -234,8 +234,14 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/sdk@0.27.3':
-    resolution: {integrity: sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw==}
+  '@anthropic-ai/sdk@0.65.0':
+    resolution: {integrity: sha512-zIdPOcrCVEI8t3Di40nH4z9EoeyGZfXbYSvWdDLsB/KkaSYMnEgC7gmcgWu83g2NTn1ZTpbMvpdttWDGGIk6zw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -307,6 +313,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
@@ -972,12 +982,6 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node-fetch@2.6.13':
-    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
-
-  '@types/node@18.19.129':
-    resolution: {integrity: sha512-hrmi5jWt2w60ayox3iIXwpMEnfUvOLJCRtrOPbHtH15nTjvO7uhnelvrdAs0dO0/zl5DZ3ZbahiaXEVb54ca/A==}
-
   '@types/node@22.18.8':
     resolution: {integrity: sha512-pAZSHMiagDR7cARo/cch1f3rXy0AEXwsVsVH09FcyeJVAzCnGgmYis7P3JidtTUjyadhTeSo8TgRPswstghDaw==}
 
@@ -1061,10 +1065,6 @@ packages:
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
 
-  abort-controller@3.0.0:
-    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
-    engines: {node: '>=6.5'}
-
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
@@ -1080,10 +1080,6 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -1142,9 +1138,6 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
-
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
@@ -1255,10 +1248,6 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -1343,10 +1332,6 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -1416,10 +1401,6 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
-  es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
-    engines: {node: '>= 0.4'}
-
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
@@ -1443,10 +1424,6 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
-
-  event-target-shim@5.0.1:
-    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
-    engines: {node: '>=6'}
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
@@ -1546,17 +1523,6 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data-encoder@1.7.2:
-    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
-
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
-    engines: {node: '>= 6'}
-
-  formdata-node@4.4.1:
-    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
-    engines: {node: '>= 12.20'}
-
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -1624,10 +1590,6 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -1638,9 +1600,6 @@ packages:
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
-
-  humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -1738,6 +1697,10 @@ packages:
 
   json-schema-ref-resolver@1.0.1:
     resolution: {integrity: sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -1974,20 +1937,6 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
-
-  node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
-
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
 
   node-releases@2.0.23:
     resolution: {integrity: sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==}
@@ -2571,9 +2520,6 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
 
@@ -2583,6 +2529,9 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -2663,9 +2612,6 @@ packages:
 
   underscore@1.13.7:
     resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
-
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -2776,21 +2722,11 @@ packages:
       jsdom:
         optional: true
 
-  web-streams-polyfill@4.0.0-beta.3:
-    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
-    engines: {node: '>= 14'}
-
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
@@ -2847,17 +2783,11 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/sdk@0.27.3':
+  '@anthropic-ai/sdk@0.65.0(zod@3.25.76)':
     dependencies:
-      '@types/node': 18.19.129
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 3.25.76
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -2947,6 +2877,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/runtime@7.28.4': {}
 
   '@babel/template@7.27.2':
     dependencies:
@@ -3434,15 +3366,6 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node-fetch@2.6.13':
-    dependencies:
-      '@types/node': 22.18.8
-      form-data: 4.0.4
-
-  '@types/node@18.19.129':
-    dependencies:
-      undici-types: 5.26.5
-
   '@types/node@22.18.8':
     dependencies:
       undici-types: 6.21.0
@@ -3557,10 +3480,6 @@ snapshots:
 
   '@xmldom/xmldom@0.8.11': {}
 
-  abort-controller@3.0.0:
-    dependencies:
-      event-target-shim: 5.0.1
-
   abstract-logging@2.0.1: {}
 
   accepts@1.3.8:
@@ -3574,10 +3493,6 @@ snapshots:
       negotiator: 1.0.0
 
   acorn@8.15.0: {}
-
-  agentkeepalive@4.6.0:
-    dependencies:
-      humanize-ms: 1.2.1
 
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
@@ -3627,8 +3542,6 @@ snapshots:
   array-flatten@1.1.1: {}
 
   assertion-error@2.0.1: {}
-
-  asynckit@0.4.0: {}
 
   atomic-sleep@1.0.0: {}
 
@@ -3763,10 +3676,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
-
   commander@4.1.1: {}
 
   confbox@0.1.8: {}
@@ -3824,8 +3733,6 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
-  delayed-stream@1.0.0: {}
-
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
@@ -3875,13 +3782,6 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
-
-  es-set-tostringtag@2.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.2
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -3947,8 +3847,6 @@ snapshots:
       '@types/estree': 1.0.8
 
   etag@1.8.1: {}
-
-  event-target-shim@5.0.1: {}
 
   eventsource-parser@3.0.6: {}
 
@@ -4139,21 +4037,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data-encoder@1.7.2: {}
-
-  form-data@4.0.4:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
-      mime-types: 2.1.35
-
-  formdata-node@4.4.1:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 4.0.0-beta.3
-
   forwarded@0.2.0: {}
 
   fraction.js@4.3.7: {}
@@ -4217,10 +4100,6 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
-
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -4234,10 +4113,6 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.1
       toidentifier: 1.0.1
-
-  humanize-ms@1.2.1:
-    dependencies:
-      ms: 2.1.3
 
   iconv-lite@0.4.24:
     dependencies:
@@ -4321,6 +4196,11 @@ snapshots:
   json-schema-ref-resolver@1.0.1:
     dependencies:
       fast-deep-equal: 3.1.3
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.28.4
+      ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
 
@@ -4640,12 +4520,6 @@ snapshots:
   negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
-
-  node-domexception@1.0.0: {}
-
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
 
   node-releases@2.0.23: {}
 
@@ -5265,8 +5139,6 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  tr46@0.0.3: {}
-
   tr46@1.0.1:
     dependencies:
       punycode: 2.3.1
@@ -5274,6 +5146,8 @@ snapshots:
   tree-kill@1.2.2: {}
 
   trough@2.2.0: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-interface-checker@0.1.13: {}
 
@@ -5355,8 +5229,6 @@ snapshots:
   ufo@1.6.1: {}
 
   underscore@1.13.7: {}
-
-  undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
 
@@ -5479,18 +5351,9 @@ snapshots:
       - supports-color
       - terser
 
-  web-streams-polyfill@4.0.0-beta.3: {}
-
-  webidl-conversions@3.0.1: {}
-
   webidl-conversions@4.0.2: {}
 
   whatwg-fetch@3.6.20: {}
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   whatwg-url@7.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- address CodeRabbit feedback: crawl politeness, transactional deletes, and summarization tool resiliency
- update Claude model to Sonnet 4.5 and refine search citation typing per review notes
- align agent route/doc headings with reviewer nitpicks while keeping custom JSON schema helper (follow-up discussion)

## Testing
- pnpm --filter @synthesis/server typecheck
- pnpm --filter @synthesis/server exec -- vitest run --pool=vmThreads
- pnpm biome check --fix apps/server/src/agent/tools.ts apps/server/src/routes/agent.ts apps/server/src/services/search.ts PHASE_3_SUMMARY.md docs/04_AGENT_TOOLS.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - /api/search vector search with top-K results and citations; /api/agent/chat conversational agent with a rich tool suite (search, ingest, web crawl, summarize, document management).

- **Improvements**
  - Robust remote file handling and storage, transactional chunk upserts with retries, consistent word counts, production CORS allowlist and DB startup validation, token usage tracking and turn limits in agent.

- **Documentation**
  - Updated phase docs, agent tooling/prompts, build plan, and migration guidance for Messages API.

- **Tests**
  - New unit, route, and E2E validations (including Playwright) covering search, agent loop, and tools.

- **Chores**
  - Anthropic SDK upgraded, claude-agent-sdk removed, env example added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
