### PR TITLE
docs: Add planning documents for future work

### DIFF
--- a/docs/agent-sdk/00_AGENT_SDK_OVERVIEW.md
+++ b/docs/agent-sdk/00_AGENT_SDK_OVERVIEW.md
@@ -71,7 +71,7 @@ Tests (`apps/server/src/agent/__tests__/agent.test.ts`, `.../routes/__tests__/ag
   - More boilerplate for multi-step workflows.
   - Every new tool and flow requires more custom control logic.
 
-##Claude Agent SDK (Agent API)
+## Claude Agent SDK (Agent API)
 
 - Higher-level **agent framework** built on top of the same underlying API [see Claude Agent SDK docs](https://docs.claude.com/en/docs/agent-sdk/overview).
 - You define:

--- a/docs/agent-sdk/00_AGENT_SDK_OVERVIEW.md
+++ b/docs/agent-sdk/00_AGENT_SDK_OVERVIEW.md
@@ -1,0 +1,154 @@
+## Agent SDK Migration Overview
+
+**Version:** 1.0  
+**Date:** 2025-11-13
+
+---
+
+### Purpose
+
+This document provides a high-level overview for migrating Synthesis from the low-level Anthropic TypeScript SDK (`@anthropic-ai/sdk`) to the higher-level Claude Agent SDK (Agent API), and for introducing richer tool orchestration and dedicated MCP servers (e.g. Context7, Synthesis MCP, new-phases MCP).
+
+The goal is to:
+
+- Keep Synthesis **simple and not over-engineered**.
+- Preserve the existing RAG pipeline and HTTP API surface.
+- Move the internal “Claude agent” implementation to the Agent SDK over time.
+- Expose all important operations (search, ingest, doc lifecycle, repo sync, etc.) as **Agent tools** and as **MCP servers**.
+
+This folder (`docs/agent-sdk`) contains the planning docs an implementation agent will need (phases, build plans, prompts, and GitHub issue templates).
+
+---
+
+### Current Agent Implementation (as of v2.0 planning)
+
+From `apps/server/src/agent/agent.ts`:
+
+- Synthesis currently uses `@anthropic-ai/sdk` directly:
+  - `import Anthropic from '@anthropic-ai/sdk';`
+  - `new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })`.
+  - `anthropic.messages.create(...)` to run a manual agent loop.
+- The loop is implemented by `runAgentChat`:
+  - It builds a **system prompt** (`BASE_SYSTEM_PROMPT`) that describes an autonomous RAG assistant for collections.
+  - It uses `buildAgentTools(db, { collectionId })` to get:
+    - `tools` (tool definitions in Anthropic Messages API format).
+    - `toolExecutors` (local functions to run when Claude emits `tool_use` blocks).
+  - It sends `messages` (history + new user message) and `tools` into `messages.create`.
+  - It parses `tool_use` blocks, calls local executors, and sends `tool_result` blocks back as user messages.
+  - It loops up to `maxTurns` (10), updating usage totals and the final assistant message.
+
+From `apps/server/src/routes/agent.ts`:
+
+- HTTP route `/api/agent/chat` validates input and calls `runAgentChat` with:
+  - `message` (user message),
+  - `collectionId`,
+  - `history` (prior user/assistant messages).
+- The route then sends back:
+  - `message` (assistant text),
+  - `tool_calls` (local record of tool calls),
+  - `history`,
+  - `usage` (token counts).
+
+Tests (`apps/server/src/agent/__tests__/agent.test.ts`, `.../routes/__tests__/agent.test.ts`) mock `@anthropic-ai/sdk` and verify this loop.
+
+**Key point:** Synthesis already has a structured internal “agent loop” and a set of tools. The migration is mostly about swapping the low-level `messages.create` loop for the Agent SDK’s agent runtime, not redesigning the entire system.
+
+---
+
+### Claude TypeScript SDK vs Agent SDK
+
+**`@anthropic-ai/sdk` (TypeScript SDK)**
+
+- Low-level, typed HTTP client for Claude’s API [as described in its repo](https://github.com/anthropics/anthropic-sdk-typescript).
+- You directly call `client.messages.create({...})` and manage:
+  - Messages and roles.
+  - Tool definitions and `tool_use` / `tool_result` parsing.
+  - Multi-turn loops, retries, streaming, and error handling.
+- Advantages:
+  - Simple dependency.
+  - Full control over prompt and flow.
+- Disadvantages for Synthesis’s goals:
+  - More boilerplate for multi-step workflows.
+  - Every new tool and flow requires more custom control logic.
+
+**Claude Agent SDK (Agent API)**
+
+- Higher-level **agent framework** built on top of the same underlying API [see Claude Agent SDK docs](https://docs.claude.com/en/docs/agent-sdk/overview).
+- You define:
+  - Tools (name, description, schema, executor function).
+  - An Agent configuration (model, system prompt, tools, limits, etc.).
+- The Agent SDK manages:
+  - Multi-turn reasoning loops.
+  - Tool selection and invocation.
+  - State between steps.
+- Advantages for Synthesis:
+  - Less custom glue code for tool orchestration.
+  - Easier to add more complex, long-running workflows (e.g. ingestion agents, doc lifecycle jobs) without re-writing the loop.
+  - More natural expression of “autonomous” behaviours.
+
+**Design decision:** For Synthesis, the Agent SDK should eventually become the **primary runtime** for agentic workflows (e.g. ingestion, doc maintenance, tool orchestration), while the TypeScript SDK can remain as a low-level client where direct calls are simpler or needed.
+
+---
+
+### Scope of Agent SDK Migration
+
+The migration should:
+
+1. **Preserve the HTTP API and core RAG pipeline**
+   - `/api/agent/chat` should keep the same contract as much as possible (or be extended carefully).
+   - `/api/search`, `/api/ingest`, `/api/docs`, `/api/synthesis/compare`, `/api/costs/*` continue to work the same.
+
+2. **Refactor the internal “agent layer” behind a clean abstraction**
+   - Introduce an internal interface like `AgentRunner` or `ClaudeAgentClient` with a method like:
+     - `run({ message, history, collectionId, context }): Promise<AgentChatResult>`.
+   - Provide two implementations:
+     - `MessagesApiAgentRunner` (current implementation using `@anthropic-ai/sdk`).
+     - `AgentSdkAgentRunner` (new implementation using Claude Agent SDK).
+   - Allow configuration/feature flag to choose implementation per environment.
+
+3. **Model Synthesis operations as Agent tools**
+   - Tools for:
+     - Search & RAG (search_rag, hybrid search variants).
+     - Document ingestion, re-ingestion, deletion.
+     - Collection management (list/create/delete collections, list documents).
+     - Doc lifecycle (marking stale, refreshing, updating metadata).
+     - Repo ingestion and sync.
+     - External MCP servers (Context7, codebase explorers, etc.).
+
+4. **Integrate MCP servers cleanly**
+   - Keep Synthesis’s MCP server(s) as first-class.
+   - Add dedicated MCP servers for:
+     - `@new-phases` (future features and planning docs).
+     - Context7-like external knowledge sources (e.g. libraries, frameworks).
+   - Make these available as tools to the Agent SDK agent.
+
+---
+
+### Design Constraints
+
+- **No over-engineering**
+  - Do not introduce a complex plugin system or generic “agent-of-agents” architecture.
+  - Keep the number of abstraction layers minimal:
+    - HTTP routes → Agent runner → Agent SDK or TS SDK → Claude.
+
+- **Incremental migration**
+  - Maintain the existing TS SDK implementation until the Agent SDK version is stable.
+  - Use a configuration flag (env var) to switch implementations.
+
+- **Backwards compatibility**
+  - Keep existing APIs and behaviours working for current users and agents.
+  - New features (e.g. advanced workflows) can depend on the Agent SDK behind feature flags.
+
+---
+
+### Documents in this Folder
+
+This folder will contain the following docs (high-level, no code):
+
+- `00_AGENT_SDK_OVERVIEW.md` (this file): summary and goals.
+- `01_AGENT_SDK_ARCHITECTURE_IMPACT.md`: which modules change, new abstractions, and tool design.
+- `02_AGENT_SDK_BUILD_PLAN.md`: phases, steps, and concrete tasks for migration and new tools/MCP servers.
+- `03_AGENT_SDK_GITHUB_ISSUES.md`: proposed GitHub issues with titles, labels, and acceptance criteria.
+- `04_AGENT_SDK_PHASE_PROMPTS.md`: suggested agent prompts for each phase so an implementation agent knows how to operate.
+
+These docs are intentionally **high level** and meant to be turned into implementation steps later by an agent, without over-complicating the design.

--- a/docs/agent-sdk/00_AGENT_SDK_OVERVIEW.md
+++ b/docs/agent-sdk/00_AGENT_SDK_OVERVIEW.md
@@ -151,4 +151,4 @@ This folder will contain the following docs (high-level, no code):
 - `03_AGENT_SDK_GITHUB_ISSUES.md`: proposed GitHub issues with titles, labels, and acceptance criteria.
 - `04_AGENT_SDK_PHASE_PROMPTS.md`: suggested agent prompts for each phase so an implementation agent knows how to operate.
 
-These docs are intentionally **high level** and meant to be turned into implementation steps later by an agent, without over-complicating the design.
+These docs are intentionally **high-level** and meant to be turned into implementation steps later by an agent, without over-complicating the design.

--- a/docs/agent-sdk/00_AGENT_SDK_OVERVIEW.md
+++ b/docs/agent-sdk/00_AGENT_SDK_OVERVIEW.md
@@ -71,7 +71,7 @@ Tests (`apps/server/src/agent/__tests__/agent.test.ts`, `.../routes/__tests__/ag
   - More boilerplate for multi-step workflows.
   - Every new tool and flow requires more custom control logic.
 
-**Claude Agent SDK (Agent API)**
+##Claude Agent SDK (Agent API)
 
 - Higher-level **agent framework** built on top of the same underlying API [see Claude Agent SDK docs](https://docs.claude.com/en/docs/agent-sdk/overview).
 - You define:

--- a/docs/agent-sdk/01_AGENT_SDK_ARCHITECTURE_IMPACT.md
+++ b/docs/agent-sdk/01_AGENT_SDK_ARCHITECTURE_IMPACT.md
@@ -1,0 +1,230 @@
+## Agent SDK Architecture Impact
+
+**Version:** 1.0  
+**Date:** 2025-11-13
+
+---
+
+### 1. Current Architecture (Relevant Parts)
+
+This section focuses on the parts of Synthesis that will be affected by migrating to the Agent SDK.
+
+#### 1.1 Agent Layer (Server)
+
+- **File:** `apps/server/src/agent/agent.ts`
+  - Contains `runAgentChat(db, params)` which:
+    - Instantiates `new Anthropic({ apiKey })` from `@anthropic-ai/sdk`.
+    - Builds a `system` prompt and `messages` (history + new user message).
+    - Calls `anthropic.messages.create` in a loop.
+    - Processes `tool_use` blocks and executes local tools via `buildAgentTools`.
+    - Adds `tool_result` blocks back into the conversation.
+    - Returns `AgentChatResult` (assistant message, toolCalls, history, usage).
+
+- **File:** `apps/server/src/agent/tools.ts` (not shown here, but referenced)
+  - Exposes `buildAgentTools(db, { collectionId })`:
+    - Returns `tools` (definitions) and `toolExecutors` (functions) for operations like search, ingest, etc.
+
+- **File:** `apps/server/src/routes/agent.ts`
+  - Defines HTTP routes:
+    - `POST /api/agent/chat` → calls `runAgentChat(getPool(), { ... })`.
+    - `POST /api/agent/fetch-web-content` → uses `fetchWebContent` service.
+    - `POST /api/agent/delete-document` → uses `deleteDocumentById`.
+
+#### 1.2 MCP Server(s)
+
+- **File:** `apps/mcp/src/index.ts` (not shown here, but referenced in docs)
+  - Implements the MCP server for Synthesis.
+  - Currently uses an API client to call the Synthesis HTTP API endpoints.
+  - Tools (MCP) map to backend operations (search, list collections/docs, ingest, etc.).
+
+#### 1.3 RAG & Services (Unchanged)
+
+- Search, ingest, synthesis, cost tracking, and code intelligence services under `apps/server/src/services/` and the DB package `packages/db` **do not need to change** for Agent SDK migration:
+  - The Agent SDK will call these operations via tools; their internal implementations remain as they are.
+
+---
+
+### 2. Target Architecture with Agent SDK
+
+We want to introduce the **Agent SDK** while keeping the rest of the system mostly intact.
+
+#### 2.1 New “Agent Runner” Abstraction
+
+Introduce an internal interface (not implemented yet, just design):
+
+```ts
+interface AgentRunner {
+  runChat(params: {
+    message: string;
+    collectionId: string;
+    history?: { role: 'user' | 'assistant'; content: string }[];
+    // optional extended context (e.g. user id, MCP server configs)
+    context?: Record<string, unknown>;
+  }): Promise<{
+    message: string;
+    toolCalls: AgentToolCall[];
+    history: AgentConversationMessage[];
+    usage?: Record<string, unknown>;
+  }>;
+}
+```
+
+Two implementations:
+
+- `MessagesApiAgentRunner` (existing behaviour):
+  - Wraps the current `runAgentChat` logic using `@anthropic-ai/sdk`.
+  - Used as default during migration.
+
+- `AgentSdkAgentRunner` (new):
+  - Uses the Claude Agent SDK to:
+    - Define tools.
+    - Run an agent with your existing `system` prompt and history.
+    - Let the Agent SDK handle tool selection, loops, and state.
+
+`apps/server/src/routes/agent.ts` would depend only on the `AgentRunner` interface, not on `@anthropic-ai/sdk` directly.
+
+#### 2.2 Tool Definition Layer
+
+Today, `buildAgentTools` returns:
+
+- `tools`: definitions compatible with `messages.create`.
+- `toolExecutors`: local functions.
+
+With the Agent SDK, tools will also be registered in the Agent SDK format. To avoid duplication:
+
+- Introduce a **single source of truth** for tool definitions and executors, e.g.:
+
+```ts
+interface AgentToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: unknown; // zod schema or JSON schema
+  executor: (input: unknown, ctx: ToolContext) => Promise<unknown>;
+}
+
+interface ToolContext {
+  db: Pool;
+  collectionId?: string;
+  // potential MCP clients, settings, etc.
+}
+```
+
+- Provide **adapters**:
+  - For the TypeScript SDK:
+    - Convert `AgentToolDefinition` into the Messages API `tools` format and map executors as today.
+  - For the Agent SDK:
+    - Register these tools directly with the Agent SDK using its native tool registration APIs.
+
+This keeps tools defined once and usable by either agent runner implementation.
+
+#### 2.3 MCP Servers & External Tools
+
+We want multiple MCP servers and external tools to be first-class in the Agent SDK:
+
+- **Synthesis MCP** (existing):
+  - Exposes core Synthesis operations (search, ingest, list/manage collections/docs) to external agents.
+
+- **New MCP servers** (planned):
+  - `@new-phases` MCP: exposes planning docs and roadmaps.
+  - Context7-like MCP: exposes external library/framework docs via the Context7 platform (or similar) so the agent can pull library-specific context.
+
+**Agent SDK integration:**
+
+- The Agent runner can expose tools that internally call MCP servers:
+  - For example, a `context7_search_docs` tool that calls the Context7 MCP server.
+  - A `new_phases_plan_lookup` tool that queries the `@new-phases` MCP server for build plans.
+- These tools are just **functions** from the Agent SDK’s perspective; MCP is an implementation detail inside the tool executor.
+
+---
+
+### 3. Minimal Changes by Layer
+
+#### 3.1 HTTP Layer (`apps/server/src/routes/agent.ts`)
+
+Minimal changes:
+
+- Replace direct calls to `runAgentChat` with a call to a configured `AgentRunner` instance.
+- Optionally add support for new parameters (e.g. agent profile, tools toggle) via non-breaking additions to the request schema.
+
+#### 3.2 Agent Layer (`apps/server/src/agent/agent.ts`)
+
+Refactoring steps (conceptual):
+
+1. Extract the `BASE_SYSTEM_PROMPT` and history handling into a shared `AgentConfig` module.
+2. Turn `runAgentChat` into a wrapper behind `AgentRunner`.
+3. Implement the `AgentSdkAgentRunner` using the Agent SDK’s recommended usage:
+   - Instantiate an Agent with:
+     - `system` (existing base prompt, possibly updated for new tools).
+     - Tools from the unified tool registry.
+   - Use the Agent SDK’s multi-turn interaction to process a single `/api/agent/chat` request, using the provided history.
+
+#### 3.3 Tool Layer (`apps/server/src/agent/tools.ts` and services)
+
+- Define tools in a **framework-neutral** shape (see `AgentToolDefinition` above).
+- Maintain a mapping from tool name → executor and schema, reusing existing services:
+  - Search RAG (hybrid/BM25/embedding).
+  - Ingest from file/URL.
+  - Collection & document management.
+  - Doc lifecycle (refresh, mark stale, etc.).
+  - Repo ingestion and sync (planned in extended roadmap).
+  - External MCP calls (Context7, `@new-phases`, etc.).
+
+#### 3.4 MCP Layer (`apps/mcp`)
+
+- No major architecture changes required:
+  - Continue to offer MCP tools that call Synthesis HTTP endpoints.
+- For the Agent SDK migration, treat MCP servers as **downstream resources** the agent can call via tools.
+
+---
+
+### 4. Configuration and Environment
+
+To keep the migration safe and flexible:
+
+- Introduce configuration flags:
+
+```bash
+# Use the legacy messages-based agent runner
+AGENT_IMPLEMENTATION=messages
+
+# Switch to Agent SDK based runner
+AGENT_IMPLEMENTATION=agent-sdk
+```
+
+- Keep `ANTHROPIC_API_KEY` as the single source of truth for authentication for both implementations.
+- Add optional config for MCP servers used by tools:
+
+```bash
+# Example
+CONTEXT7_MCP_SERVER_URL=...
+NEW_PHASES_MCP_SERVER_URL=...
+SYNTHESIS_MCP_SERVER_URL=...
+```
+
+---
+
+### 5. Non-Goals (to avoid over-engineering)
+
+- Do **not**:
+  - Build a generic plugin system for agents.
+  - Introduce multiple competing agent frameworks at the same time.
+  - Create a separate microservice just to host the agent logic.
+
+- Do instead:
+  - Keep the agent implementation inside the existing server app.
+  - Use a simple `AgentRunner` interface and two concrete implementations.
+  - Use tool definitions as the main extension point.
+
+---
+
+### 6. Summary
+
+- The migration is mostly **localised** to:
+  - `apps/server/src/agent/agent.ts` (agent loop)
+  - `apps/server/src/agent/tools.ts` (tool definitions)
+  - `apps/server/src/routes/agent.ts` (HTTP entrypoint)
+- RAG services, DB schema, MCP server, and frontend remain largely unchanged.
+- Introducing a clean `AgentRunner` abstraction and a unified tool registry allows Synthesis to:
+  - Keep the existing messages-based implementation.
+  - Gradually adopt the Claude Agent SDK.
+  - Add richer tools and MCP integrations (Context7, new-phases) without over-engineering.

--- a/docs/agent-sdk/02_AGENT_SDK_BUILD_PLAN.md
+++ b/docs/agent-sdk/02_AGENT_SDK_BUILD_PLAN.md
@@ -1,0 +1,267 @@
+## Agent SDK Migration & Tools Build Plan
+
+**Version:** 1.0  
+**Date:** 2025-11-13
+
+---
+
+### Overview
+
+This document outlines a **high-level build plan** for:
+
+1. Migrating Synthesis’s internal agent implementation from the low-level TypeScript SDK to the Claude Agent SDK.
+2. Defining a unified tool registry usable by both implementations.
+3. Exposing key operations as tools (search, ingest, lifecycle, repo sync, MCP integrations).
+4. Adding dedicated MCP servers (including Context7-like sources and `@new-phases`).
+
+The plan is organized into phases to keep the work incremental and avoid over-engineering. No code is written here; this is a guide for a future implementation agent.
+
+**Branch Strategy (high level)**
+
+- Keep the **`main` branch** as the Messages API–based implementation (v2.0 line).
+- Use an **`agent-sdk` (or `develop`) branch** for the Agent SDK migration and related tools/MCP work.
+- Regularly merge `main` into `agent-sdk` to keep the migration up to date.
+- Use `AGENT_IMPLEMENTATION=messages|agent-sdk` as a runtime flag so both implementations can coexist in the same codebase if desired.
+
+---
+
+### Phase A — Baseline Audit & Abstractions
+
+**Goal:** Understand the current implementation deeply and introduce minimal abstractions without behaviour changes.
+
+**A1. Audit current agent & tools implementation**
+
+- Files:
+  - `apps/server/src/agent/agent.ts` — current agent loop using `@anthropic-ai/sdk`.
+  - `apps/server/src/agent/tools.ts` — current tool definitions and executors.
+  - `apps/server/src/routes/agent.ts` — HTTP routes using `runAgentChat`.
+  - `apps/mcp/src/index.ts` — MCP server exposing Synthesis operations.
+
+**Tasks:**
+
+- Document:
+  - The exact shape of `AgentConversationMessage`, `AgentChatParams`, `AgentToolCall`, `AgentChatResult`.
+  - The set of tools provided by `buildAgentTools` (names, inputs, outputs).
+  - Error handling patterns in `runAgentChat` and `agentRoutes`.
+
+**A2. Introduce AgentRunner interface (conceptual)**
+
+- Design `AgentRunner` interface (see `01_AGENT_SDK_ARCHITECTURE_IMPACT.md`).
+- Plan how to:
+  - Wrap current `runAgentChat` inside a `MessagesApiAgentRunner`.
+  - Create a placeholder `AgentSdkAgentRunner` with `TODO` sections.
+
+**A3. Configuration planning**
+
+- Decide env variables for switching implementations:
+  - `AGENT_IMPLEMENTATION=messages | agent-sdk`.
+- Plan how the server will construct the correct runner at startup.
+
+**Exit Criteria (Phase A):**
+
+- Clear understanding of the current agent loop and tools.
+- Design for `AgentRunner` and configuration toggles.
+- No behavioural changes yet.
+
+---
+
+### Phase B — Unified Tool Registry
+
+**Goal:** Define a single, neutral representation of tools that can be consumed by both agent implementations and MCP.
+
+**B1. Tool definition format**
+
+- Define `AgentToolDefinition` and `ToolContext` (see architecture doc).
+- Identify all existing tools in `buildAgentTools` and map them into:
+  - `name`, `description`, `inputSchema` (zod/JSON-schema), `executor`.
+
+**B2. Adapter for Messages API**
+
+- Plan an adapter that:
+  - Takes an array of `AgentToolDefinition` and produces `Tool[]` for `messages.create`.
+  - Provides `toolExecutors` lookup by name.
+
+**B3. Adapter for Agent SDK**
+
+- Plan how to register the same `AgentToolDefinition` set with the Agent SDK.
+- Consider how to pass context (db, collectionId, MCP clients) into executors.
+
+**B4. MCP alignment**
+
+- Ensure MCP tools (in `apps/mcp/src/index.ts`) can reuse the same definitions or at least the same business logic.
+
+**Exit Criteria (Phase B):**
+
+- A clearly defined tool registry design.
+- Mapping from existing tools to this registry is understood and enumerated.
+
+---
+
+### Phase C — Agent SDK Runner Implementation (Behind a Flag)
+
+**Goal:** Implement `AgentSdkAgentRunner` using the Claude Agent SDK while keeping the existing `MessagesApiAgentRunner` intact.
+
+> Note: This phase is design-only; a future agent will fill in actual imports and code once the Agent SDK WSL issue is resolved.
+
+**C1. Agent SDK client & agent config design**
+
+- Define how to instantiate the Agent SDK client (equivalent to current `new Anthropic(...)`).
+- Decide on an `Agent` configuration:
+  - Model (e.g., `claude-3-7-sonnet` equivalent).
+  - System prompt (based on `BASE_SYSTEM_PROMPT`, possibly updated for new tools).
+  - Tools (from unified registry).
+  - Limits: max turns, token budgets.
+
+**C2. AgentSdkAgentRunner.runChat behaviour**
+
+- Map `/api/agent/chat` request fields to Agent SDK calls:
+  - `message` → initial/user message.
+  - `history` → prior messages.
+  - `collectionId` → part of system or per-call context.
+- Decide how to:
+  - Feed history into the Agent SDK (messages or conversation state).
+  - Run a single logical “turn” (call) that may internally perform multiple tool uses.
+  - Extract the final assistant message and tool call information for the response.
+
+**C3. Tool execution & context**
+
+- Plan how the Agent SDK will call tools and how executors receive:
+  - `db` connection.
+  - `collectionId`.
+  - MCP clients (if needed).
+
+**C4. Usage & logging**
+
+- Decide how to aggregate usage (tokens) from the Agent SDK responses into `usage` fields that match current `AgentChatResult`.
+
+**Exit Criteria (Phase C):**
+
+- Clear design for `AgentSdkAgentRunner`, including interaction with history, tools, and usage.
+- Plan for maintaining compatibility with current `/api/agent/chat` response shape.
+
+---
+
+### Phase D — Tools Expansion for Synthesis & MCP
+
+**Goal:** Expand the set of tools to cover all key operations Synthesis and your coding agents need, including new-phase features and external MCP servers.
+
+**D1. Core RAG tools**
+
+- `search_rag` — existing.
+- `search_hybrid`, `search_code`, `search_docs` — optional specialized variants.
+- `get_document_chunks`, `get_related_files` — for direct context retrieval.
+
+**D2. Collection & document management tools**
+
+- `list_collections`, `create_collection`, `delete_collection`.
+- `list_documents`, `get_document`, `delete_document`.
+- `add_document_from_file`, `add_document_from_url`.
+
+**D3. Doc lifecycle tools (from new-phases plans)**
+
+- `refresh_document` — triggers re-ingestion of a stale document.
+- `mark_document_stale` / `check_document_freshness` — for scheduled jobs.
+- `update_document_metadata` — allows manual metadata edits.
+
+**D4. Repo ingestion & sync tools (from extended tech stack plan)**
+
+- `add_repo_to_collection` — clone & ingest a repo.
+- `sync_repo` — pull & diff to update changed files only.
+- Optional: `list_repos`, `get_repo_status` for monitoring.
+
+**D5. External MCP / Context7 tools**
+
+- `context7_search_docs` — call Context7 MCP server for library/framework docs.
+- `new_phases_plan_lookup` — query the `@new-phases` MCP server for future plans.
+- `synthesis_mcp_search` — self-call to Synthesis MCP from within the Agent SDK for meta workflows.
+
+**D6. Utility tools**
+
+- `log_feedback` — record thumbs up/down on answers.
+- `report_issue` — create an issue stub in a repo or internal log.
+
+**Exit Criteria (Phase D):**
+
+- A catalog of tools and their input/output shapes is defined.
+- Each tool is mapped to an existing or planned backend/service function.
+
+---
+
+### Phase E — MCP Servers and Integration
+
+**Goal:** Ensure MCP servers align with the new tool design and are easily callable by the Agent SDK.
+
+**E1. Synthesis MCP alignment**
+
+- Verify the Synthesis MCP server exposes:
+  - Search operations.
+  - Collection/document listing and management.
+  - Ingestion operations.
+- Plan MCP tool descriptions that match the Agent SDK tools where practical.
+
+**E2. New MCP servers**
+
+- `new-phases` MCP:
+  - Expose planning docs from `docs/new-phases` and `docs/agent-sdk`.
+  - Tools for “get plan for X”, “list phases for Y”, etc.
+
+- Context7-like MCP:
+  - Tools to search doc sets for libraries/frameworks by name, version, and topic.
+
+**E3. Agent SDK integration**
+
+- For each MCP server, decide how to:
+  - Instantiate a client (HTTP/MCP transport).
+  - Wire it into tool executors.
+
+**Exit Criteria (Phase E):**
+
+- Design for MCP integration via tools is clear.
+- MCP servers’ responsibilities and boundaries are well understood.
+
+---
+
+### Phase F — Testing, Rollout, and Cleanup
+
+**Goal:** Adopt the Agent SDK implementation safely and gradually.
+
+**F1. Dual-mode testing strategy**
+
+- Keep both `MessagesApiAgentRunner` and `AgentSdkAgentRunner` implementations available.
+- Add tests that:
+  - Exercise the same scenarios against both implementations.
+  - Compare outputs for core behaviour (allowing some flexibility in wording).
+
+**F2. Rollout strategy**
+
+- Development / staging:
+  - Use `AGENT_IMPLEMENTATION=agent-sdk`.
+  - Run regression tests and manual scenarios.
+
+- Production (for you / early adopters):
+  - Start with `AGENT_IMPLEMENTATION=messages`.
+  - Gradually enable `agent-sdk` in a controlled environment.
+
+**F3. Cleanup (optional, later)**
+
+- Once satisfied, optionally:
+  - Make `agent-sdk` the default implementation.
+  - Keep the messages-based implementation as a fallback or remove it if no longer needed.
+
+**Exit Criteria (Phase F):**
+
+- Agent SDK implementation is stable and optionally the default.
+- The system still feels simple and not over-engineered.
+
+---
+
+### Summary
+
+This build plan keeps the migration **incremental** and **contained**:
+
+- Phase A–C focus on abstraction and new Agent SDK runner.
+- Phase B & D define and expand tools in a unified way.
+- Phase E integrates MCP servers and external knowledge sources.
+- Phase F handles testing and gradual rollout.
+
+A future implementation agent can take these phases, create more detailed day-by-day tasks, and implement them without disrupting Synthesis’s overall architecture or over-complicating the design.

--- a/docs/agent-sdk/02_AGENT_SDK_BUILD_PLAN.md
+++ b/docs/agent-sdk/02_AGENT_SDK_BUILD_PLAN.md
@@ -29,7 +29,7 @@ The plan is organized into phases to keep the work incremental and avoid over-en
 
 **Goal:** Understand the current implementation deeply and introduce minimal abstractions without behaviour changes.
 
-**A1. Audit current agent & tools implementation**
+### A1. Audit current agent & tools implementation
 
 - Files:
   - `apps/server/src/agent/agent.ts` — current agent loop using `@anthropic-ai/sdk`.
@@ -44,14 +44,14 @@ The plan is organized into phases to keep the work incremental and avoid over-en
   - The set of tools provided by `buildAgentTools` (names, inputs, outputs).
   - Error handling patterns in `runAgentChat` and `agentRoutes`.
 
-**A2. Introduce AgentRunner interface (conceptual)**
+### A2. Introduce AgentRunner interface (conceptual)
 
 - Design `AgentRunner` interface (see `01_AGENT_SDK_ARCHITECTURE_IMPACT.md`).
 - Plan how to:
   - Wrap current `runAgentChat` inside a `MessagesApiAgentRunner`.
   - Create a placeholder `AgentSdkAgentRunner` with `TODO` sections.
 
-**A3. Configuration planning**
+### A3. Configuration planning
 
 - Decide env variables for switching implementations:
   - `AGENT_IMPLEMENTATION=messages | agent-sdk`.
@@ -69,24 +69,24 @@ The plan is organized into phases to keep the work incremental and avoid over-en
 
 **Goal:** Define a single, neutral representation of tools that can be consumed by both agent implementations and MCP.
 
-**B1. Tool definition format**
+### B1. Tool definition format
 
 - Define `AgentToolDefinition` and `ToolContext` (see architecture doc).
 - Identify all existing tools in `buildAgentTools` and map them into:
   - `name`, `description`, `inputSchema` (zod/JSON-schema), `executor`.
 
-**B2. Adapter for Messages API**
+### B2. Adapter for Messages API
 
 - Plan an adapter that:
   - Takes an array of `AgentToolDefinition` and produces `Tool[]` for `messages.create`.
   - Provides `toolExecutors` lookup by name.
 
-**B3. Adapter for Agent SDK**
+### B3. Adapter for Agent SDK
 
 - Plan how to register the same `AgentToolDefinition` set with the Agent SDK.
 - Consider how to pass context (db, collectionId, MCP clients) into executors.
 
-**B4. MCP alignment**
+### B4. MCP alignment
 
 - Ensure MCP tools (in `apps/mcp/src/index.ts`) can reuse the same definitions or at least the same business logic.
 
@@ -103,7 +103,7 @@ The plan is organized into phases to keep the work incremental and avoid over-en
 
 > Note: This phase is design-only; a future agent will fill in actual imports and code once the Agent SDK WSL issue is resolved.
 
-**C1. Agent SDK client & agent config design**
+### C1. Agent SDK client & agent config design
 
 - Define how to instantiate the Agent SDK client (equivalent to current `new Anthropic(...)`).
 - Decide on an `Agent` configuration:
@@ -112,7 +112,7 @@ The plan is organized into phases to keep the work incremental and avoid over-en
   - Tools (from unified registry).
   - Limits: max turns, token budgets.
 
-**C2. AgentSdkAgentRunner.runChat behaviour**
+### C2. AgentSdkAgentRunner.runChat behaviour
 
 - Map `/api/agent/chat` request fields to Agent SDK calls:
   - `message` → initial/user message.
@@ -123,14 +123,14 @@ The plan is organized into phases to keep the work incremental and avoid over-en
   - Run a single logical “turn” (call) that may internally perform multiple tool uses.
   - Extract the final assistant message and tool call information for the response.
 
-**C3. Tool execution & context**
+### C3. Tool execution & context
 
 - Plan how the Agent SDK will call tools and how executors receive:
   - `db` connection.
   - `collectionId`.
   - MCP clients (if needed).
 
-**C4. Usage & logging**
+### C4. Usage & logging
 
 - Decide how to aggregate usage (tokens) from the Agent SDK responses into `usage` fields that match current `AgentChatResult`.
 
@@ -145,37 +145,37 @@ The plan is organized into phases to keep the work incremental and avoid over-en
 
 **Goal:** Expand the set of tools to cover all key operations Synthesis and your coding agents need, including new-phase features and external MCP servers.
 
-**D1. Core RAG tools**
+### D1. Core RAG tools
 
 - `search_rag` — existing.
 - `search_hybrid`, `search_code`, `search_docs` — optional specialized variants.
 - `get_document_chunks`, `get_related_files` — for direct context retrieval.
 
-**D2. Collection & document management tools**
+### D2. Collection & document management tools
 
 - `list_collections`, `create_collection`, `delete_collection`.
 - `list_documents`, `get_document`, `delete_document`.
 - `add_document_from_file`, `add_document_from_url`.
 
-**D3. Doc lifecycle tools (from new-phases plans)**
+### D3. Doc lifecycle tools (from new-phases plans)
 
 - `refresh_document` — triggers re-ingestion of a stale document.
 - `mark_document_stale` / `check_document_freshness` — for scheduled jobs.
 - `update_document_metadata` — allows manual metadata edits.
 
-**D4. Repo ingestion & sync tools (from extended tech stack plan)**
+### D4. Repo ingestion & sync tools (from extended tech stack plan)
 
 - `add_repo_to_collection` — clone & ingest a repo.
 - `sync_repo` — pull & diff to update changed files only.
 - Optional: `list_repos`, `get_repo_status` for monitoring.
 
-**D5. External MCP / Context7 tools**
+### D5. External MCP / Context7 tools
 
 - `context7_search_docs` — call Context7 MCP server for library/framework docs.
 - `new_phases_plan_lookup` — query the `@new-phases` MCP server for future plans.
 - `synthesis_mcp_search` — self-call to Synthesis MCP from within the Agent SDK for meta workflows.
 
-**D6. Utility tools**
+### D6. Utility tools
 
 - `log_feedback` — record thumbs up/down on answers.
 - `report_issue` — create an issue stub in a repo or internal log.
@@ -191,7 +191,7 @@ The plan is organized into phases to keep the work incremental and avoid over-en
 
 **Goal:** Ensure MCP servers align with the new tool design and are easily callable by the Agent SDK.
 
-**E1. Synthesis MCP alignment**
+### E1. Synthesis MCP alignment
 
 - Verify the Synthesis MCP server exposes:
   - Search operations.
@@ -199,7 +199,7 @@ The plan is organized into phases to keep the work incremental and avoid over-en
   - Ingestion operations.
 - Plan MCP tool descriptions that match the Agent SDK tools where practical.
 
-**E2. New MCP servers**
+### E2. New MCP servers
 
 - `new-phases` MCP:
   - Expose planning docs from `docs/new-phases` and `docs/agent-sdk`.
@@ -208,7 +208,7 @@ The plan is organized into phases to keep the work incremental and avoid over-en
 - Context7-like MCP:
   - Tools to search doc sets for libraries/frameworks by name, version, and topic.
 
-**E3. Agent SDK integration**
+### E3. Agent SDK integration
 
 - For each MCP server, decide how to:
   - Instantiate a client (HTTP/MCP transport).
@@ -225,14 +225,14 @@ The plan is organized into phases to keep the work incremental and avoid over-en
 
 **Goal:** Adopt the Agent SDK implementation safely and gradually.
 
-**F1. Dual-mode testing strategy**
+### F1. Dual-mode testing strategy
 
 - Keep both `MessagesApiAgentRunner` and `AgentSdkAgentRunner` implementations available.
 - Add tests that:
   - Exercise the same scenarios against both implementations.
   - Compare outputs for core behaviour (allowing some flexibility in wording).
 
-**F2. Rollout strategy**
+### F2. Rollout strategy
 
 - Development / staging:
   - Use `AGENT_IMPLEMENTATION=agent-sdk`.
@@ -242,7 +242,7 @@ The plan is organized into phases to keep the work incremental and avoid over-en
   - Start with `AGENT_IMPLEMENTATION=messages`.
   - Gradually enable `agent-sdk` in a controlled environment.
 
-**F3. Cleanup (optional, later)**
+### F3. Cleanup (optional, later)
 
 - Once satisfied, optionally:
   - Make `agent-sdk` the default implementation.

--- a/docs/agent-sdk/03_AGENT_SDK_GITHUB_ISSUES.md
+++ b/docs/agent-sdk/03_AGENT_SDK_GITHUB_ISSUES.md
@@ -1,0 +1,248 @@
+## Agent SDK Migration — Proposed GitHub Issues
+
+**Version:** 1.0  
+**Date:** 2025-11-13
+
+---
+
+### Overview
+
+This document defines a set of **proposed GitHub issues** for the Agent SDK migration and related tool/MCP work. These are not created yet; they are templates that can be copied into GitHub later.
+
+Suggested labels:
+
+- `agent-sdk`
+- `refactor`
+- `feature`
+- `mcp`
+- `priority:high` / `priority:medium`
+
+Milestone name (example, to avoid confusion with existing phases):
+
+- `Milestone: Agent SDK Migration`
+
+---
+
+### Issue 1 — Refactor Agent Layer to AgentRunner Abstraction
+
+**Title:** `refactor(agent): Introduce AgentRunner abstraction and keep messages-based implementation`
+
+**Labels:** `agent-sdk`, `refactor`, `priority:high`
+
+**Description:**
+
+Refactor the current agent implementation to use a pluggable `AgentRunner` abstraction while preserving the existing `@anthropic-ai/sdk` Messages API behaviour.
+
+**Acceptance Criteria:**
+
+- [ ] A `AgentRunner` interface is defined (or equivalent) representing `runChat` behaviour.
+- [ ] `MessagesApiAgentRunner` wraps the existing `runAgentChat` logic.
+- [ ] `apps/server/src/routes/agent.ts` uses `AgentRunner` rather than calling `runAgentChat` directly.
+- [ ] Configuration is added to select the implementation (e.g., `AGENT_IMPLEMENTATION=messages`).
+- [ ] All existing tests for agent routes and `runAgentChat` pass unchanged.
+
+**References:**
+
+- `docs/agent-sdk/00_AGENT_SDK_OVERVIEW.md`
+- `docs/agent-sdk/01_AGENT_SDK_ARCHITECTURE_IMPACT.md`
+- `apps/server/src/agent/agent.ts`
+- `apps/server/src/routes/agent.ts`
+
+---
+
+### Issue 2 — Create Unified Tool Registry
+
+**Title:** `feat(agent): Define unified tool registry for agent and MCP`
+
+**Labels:** `agent-sdk`, `feature`, `priority:high`
+
+**Description:**
+
+Define a single source of truth for Synthesis tools (search, ingest, management, etc.) that can be used by:
+
+- The existing messages-based agent implementation.
+- The new Agent SDK-based agent implementation.
+- MCP servers (where appropriate).
+
+**Acceptance Criteria:**
+
+- [ ] An `AgentToolDefinition` type is created with `name`, `description`, `inputSchema`, and `executor`.
+- [ ] Existing tools from `buildAgentTools` are mapped into this registry.
+- [ ] Adapters exist to:
+  - [ ] Convert the registry to Messages API `tools` format + executor map.
+  - [ ] Prepare tool definitions for Agent SDK registration.
+- [ ] No behaviour change for the current `/api/agent/chat` route.
+
+**References:**
+
+- `docs/agent-sdk/01_AGENT_SDK_ARCHITECTURE_IMPACT.md`
+- `docs/agent-sdk/02_AGENT_SDK_BUILD_PLAN.md` (Phase B)
+
+---
+
+### Issue 3 — Implement AgentSdkAgentRunner (Behind Flag)
+
+**Title:** `feat(agent-sdk): Implement AgentSdkAgentRunner behind feature flag`
+
+**Labels:** `agent-sdk`, `feature`, `priority:high`
+
+**Description:**
+
+Implement an `AgentSdkAgentRunner` using the Claude Agent SDK that mirrors the behaviour of the existing messages-based agent. Keep this behind a feature flag and do not enable it in production initially.
+
+**Acceptance Criteria:**
+
+- [ ] Agent SDK client initialization is implemented (using `ANTHROPIC_API_KEY`).
+- [ ] `AgentSdkAgentRunner.runChat` accepts `message`, `history`, and `collectionId` and returns a result compatible with `AgentChatResult`.
+- [ ] Tools from the unified registry are registered with the Agent SDK.
+- [ ] Internal multi-turn reasoning is handled by the Agent SDK (no manual tool loop).
+- [ ] Configuration `AGENT_IMPLEMENTATION=agent-sdk` selects this runner.
+- [ ] Tests verify basic parity with the messages-based implementation for core scenarios.
+
+**References:**
+
+- `docs/agent-sdk/01_AGENT_SDK_ARCHITECTURE_IMPACT.md`
+- `docs/agent-sdk/02_AGENT_SDK_BUILD_PLAN.md` (Phase C)
+- Claude Agent SDK docs: `https://docs.claude.com/en/docs/agent-sdk/overview`
+
+---
+
+### Issue 4 — Expand Tools for RAG, Lifecycle, and Repos
+
+**Title:** `feat(agent-sdk): Expand tool set for RAG, lifecycle, and repo ingestion`
+
+**Labels:** `agent-sdk`, `feature`, `priority:medium`
+
+**Description:**
+
+Expand the tool registry to cover all important Synthesis operations for your coding agents, including RAG, document lifecycle management, and repo ingestion/sync.
+
+**Acceptance Criteria:**
+
+- [ ] RAG tools added: `search_rag`, `search_code`, `get_document_chunks`, `get_related_files`.
+- [ ] Collection tools: `list_collections`, `create_collection`, `delete_collection`.
+- [ ] Document tools: `list_documents`, `get_document`, `add_document_from_url`, `delete_document`.
+- [ ] Lifecycle tools: `refresh_document`, `check_document_freshness`, `update_document_metadata`.
+- [ ] Repo tools: `add_repo_to_collection`, `sync_repo`, `get_repo_status`.
+- [ ] Each tool is wired to an existing (or planned) backend service.
+
+**References:**
+
+- `docs/new-phases/01_BUILD_PLAN.md`
+- `docs/new-phases/07_EXTENDED_TECH_STACK_AND_REPO_INGESTION_PLAN.md`
+- `docs/agent-sdk/02_AGENT_SDK_BUILD_PLAN.md` (Phase D)
+
+---
+
+### Issue 5 — Integrate MCP Servers (Synthesis, new-phases, Context7)
+
+**Title:** `feat(mcp): Integrate Synthesis, new-phases, and Context7 MCP servers into agent tools`
+
+**Labels:** `agent-sdk`, `mcp`, `feature`, `priority:medium`
+
+**Description:**
+
+Integrate multiple MCP servers into the Agent SDK via tools so the agent can:
+
+- Query Synthesis itself via MCP (meta workflows).
+- Use `@new-phases` MCP to look up future plans and docs.
+- Use a Context7-like MCP server to retrieve external library and framework docs.
+
+**Acceptance Criteria:**
+
+- [ ] Existing Synthesis MCP server is inventoried and documented.
+- [ ] `new-phases` MCP server is designed (or implemented) with tools that expose planning docs.
+- [ ] Context7-style MCP client is designed for external doc search.
+- [ ] Agent tools are added:
+  - [ ] `synthesis_mcp_search`
+  - [ ] `new_phases_plan_lookup`
+  - [ ] `context7_search_docs`
+- [ ] Tools are usable by both Messages API and Agent SDK implementations.
+
+**References:**
+
+- `docs/new-phases/06_PHASE_15_17_STATUS_REPORT.md`
+- `docs/new-phases/07_EXTENDED_TECH_STACK_AND_REPO_INGESTION_PLAN.md`
+- `docs/agent-sdk/02_AGENT_SDK_BUILD_PLAN.md` (Phase E)
+
+---
+
+### Issue 6 — Dual-Mode Testing & Rollout
+
+**Title:** `chore(agent-sdk): Add dual-mode tests and rollout strategy for Agent SDK`
+
+**Labels:** `agent-sdk`, `refactor`, `priority:medium`
+
+**Description:**
+
+Ensure safe rollout of the Agent SDK implementation by running both implementations side-by-side in tests and providing a clear deployment strategy.
+
+**Acceptance Criteria:**
+
+- [ ] Tests exist that can run key scenarios with both `MessagesApiAgentRunner` and `AgentSdkAgentRunner`.
+- [ ] Differences in wording are tolerated but core behaviour (tool usage, outcomes) is validated.
+- [ ] Configuration-driven selection (`AGENT_IMPLEMENTATION`) is documented.
+- [ ] A brief rollout plan is documented in `docs/agent-sdk/02_AGENT_SDK_BUILD_PLAN.md`.
+
+**References:**
+
+- `docs/agent-sdk/02_AGENT_SDK_BUILD_PLAN.md` (Phase F)
+
+---
+
+### Issue 7 — Update Documentation for Agent SDK Migration
+
+**Title:** `docs(agent-sdk): Document Agent SDK architecture and usage`
+
+**Labels:** `agent-sdk`, `documentation`, `priority:medium`
+
+**Description:**
+
+Update documentation to explain the new Agent SDK-based architecture and how tools, MCP servers, and agents fit together.
+
+**Acceptance Criteria:**
+
+- [ ] `docs/agent-sdk/00_AGENT_SDK_OVERVIEW.md` is finalized to match implementation.
+- [ ] `docs/agent-sdk/01_AGENT_SDK_ARCHITECTURE_IMPACT.md` reflects actual architecture.
+- [ ] Main architecture docs (`docs/02_ARCHITECTURE.md`, `docs/04_AGENT_TOOLS.md`) are updated with the new agent layer design.
+- [ ] New-phase docs that reference agents and tools are cross-linked to the Agent SDK docs.
+
+**References:**
+
+- `docs/agent-sdk/*`
+- `docs/04_AGENT_TOOLS.md`
+- `docs/02_ARCHITECTURE.md`
+
+---
+
+### Issue 8 — (Optional) Remove Legacy Messages-Based Implementation
+
+**Title:** `chore(agent-sdk): Remove legacy messages-based Agent implementation (optional)`
+
+**Labels:** `agent-sdk`, `refactor`, `priority:low`
+
+**Description:**
+
+After the Agent SDK implementation has been stable for a while, consider removing the legacy messages-based agent implementation to simplify the codebase.
+
+**Acceptance Criteria:**
+
+- [ ] Decision is made whether to keep or remove the messages-based implementation.
+- [ ] If removed, all references to the old implementation are deleted.
+- [ ] Tests and docs are updated accordingly.
+
+**References:**
+
+- Previous issues in this document.
+- `docs/agent-sdk/02_AGENT_SDK_BUILD_PLAN.md` (Phase F)
+
+---
+
+### Notes
+
+- These issues are intentionally high-level and should be broken down further by an implementation agent if needed.
+- They are designed to avoid over-engineering by focusing on:
+  - A single `AgentRunner` abstraction.
+  - A unified tool registry.
+  - Incremental adoption of the Agent SDK.
+  - Clear boundaries between the agent layer, RAG services, and MCP servers.

--- a/docs/agent-sdk/04_AGENT_SDK_PHASE_PROMPTS.md
+++ b/docs/agent-sdk/04_AGENT_SDK_PHASE_PROMPTS.md
@@ -1,0 +1,191 @@
+## Agent SDK Migration — Phase Prompts for Implementation Agents
+
+**Version:** 1.0  
+**Date:** 2025-11-13
+
+---
+
+### Purpose
+
+This document provides **prompt templates** for each planned phase of the Agent SDK migration work. The idea is that you (or a future implementation agent) can:
+
+- Pick a phase.
+- Use the corresponding prompt as the system/user instructions.
+- Execute that phase’s work with clear constraints (no over-engineering, no scope creep).
+
+These prompts assume the agent already has access to the Synthesis codebase and documentation.
+
+---
+
+### General System Prompt (for all phases)
+
+You can reuse this as a base system prompt, then add a phase-specific section.
+
+> **System Prompt (base)**  
+> You are an experienced TypeScript backend engineer working on the Synthesis project.  
+> Synthesis is a RAG system with a Fastify backend, React frontend, PostgreSQL/pgvector, and a Claude-based agent layer.  
+> The current agent is implemented using the `@anthropic-ai/sdk` Messages API with a manual tool-use loop; we want to migrate to the Claude Agent SDK (Agent API) gradually while keeping the system simple and not over-engineered.  
+> You must carefully follow the design and constraints in `docs/agent-sdk/*`, `docs/new-phases/*`, and the existing architecture docs.  
+> In this phase, you will work strictly within the scope defined in the phase-specific instructions.  
+> Do not introduce new abstractions beyond what is planned unless absolutely necessary and justified in comments.  
+> Prefer small, incremental changes and keep public APIs stable.  
+> When in doubt, favor clarity and maintainability over cleverness.
+
+---
+
+### Phase A — Baseline Audit & Abstractions
+
+> **User Prompt (Phase A)**  
+> Phase: A — Baseline Audit & Abstractions.  
+> Objective: Understand the current agent implementation and introduce a minimal `AgentRunner` abstraction without changing behaviour.  
+> 
+> 1. Read these docs and files carefully:  
+>    - `docs/agent-sdk/00_AGENT_SDK_OVERVIEW.md`  
+>    - `docs/agent-sdk/01_AGENT_SDK_ARCHITECTURE_IMPACT.md`  
+>    - `apps/server/src/agent/agent.ts`  
+>    - `apps/server/src/agent/tools.ts`  
+>    - `apps/server/src/routes/agent.ts`  
+>    - Agent-related tests under `apps/server/src/agent/__tests__/` and `apps/server/src/routes/__tests__/agent.test.ts`.  
+> 2. Introduce an internal `AgentRunner` interface that abstracts `runChat` behaviour, as described in the docs, but keep the existing messages-based implementation intact.  
+> 3. Implement `MessagesApiAgentRunner` as a thin wrapper around the existing `runAgentChat` logic.  
+> 4. Update `apps/server/src/routes/agent.ts` to depend on `AgentRunner` instead of calling `runAgentChat` directly.  
+> 5. Add configuration (e.g., `AGENT_IMPLEMENTATION`) but default to the current messages-based implementation.  
+> 6. Do not yet introduce the Agent SDK or change any tool definitions in this phase.  
+> 7. Ensure all existing tests still pass and add tests only where necessary to validate the new abstraction.  
+> 
+> Constraints:  
+> - No over-engineering: do not add more layers than `AgentRunner` + `MessagesApiAgentRunner`.  
+> - No behavioural changes: the HTTP API and agent behaviour should be identical.  
+> - Keep changes local to the agent layer and routes.
+
+---
+
+### Phase B — Unified Tool Registry
+
+> **User Prompt (Phase B)**  
+> Phase: B — Unified Tool Registry.  
+> Objective: Create a single tool registry used by both the messages-based agent and the future Agent SDK agent.  
+> 
+> 1. Read:  
+>    - `docs/agent-sdk/01_AGENT_SDK_ARCHITECTURE_IMPACT.md` (tool registry section).  
+>    - `docs/agent-sdk/02_AGENT_SDK_BUILD_PLAN.md` (Phase B).  
+>    - `apps/server/src/agent/tools.ts`.  
+> 2. Design and implement an `AgentToolDefinition` type and any necessary supporting types (e.g., `ToolContext`).  
+> 3. Refactor `buildAgentTools` (or equivalent) to construct a list of `AgentToolDefinition` instances instead of ad-hoc structures.  
+> 4. Implement an adapter that converts `AgentToolDefinition[]` into:  
+>    - The Messages API `tools` format, and  
+>    - A map of tool executors keyed by name.  
+> 5. Update the existing messages-based agent implementation to use this registry and adapter.  
+> 6. Do not implement Agent SDK usage yet in this phase.  
+> 7. Ensure no changes to tool behaviour; all tests must still pass.  
+> 
+> Constraints:  
+> - Minimal changes: reuse existing executors and service functions.  
+> - No new tools yet; simply re-model the current ones.  
+> - Avoid circular dependencies between registry, agent, and MCP.
+
+---
+
+### Phase C — AgentSdkAgentRunner Implementation
+
+> **User Prompt (Phase C)**  
+> Phase: C — AgentSdkAgentRunner Implementation.  
+> Objective: Implement `AgentSdkAgentRunner` using the Claude Agent SDK, behind a feature flag, while preserving compatibility.  
+> 
+> 1. Read:  
+>    - `docs/agent-sdk/01_AGENT_SDK_ARCHITECTURE_IMPACT.md` (AgentSdkAgentRunner section).  
+>    - `docs/agent-sdk/02_AGENT_SDK_BUILD_PLAN.md` (Phase C).  
+>    - Claude Agent SDK docs: `https://docs.claude.com/en/docs/agent-sdk/overview`.  
+> 2. Implement `AgentSdkAgentRunner` that:  
+>    - Uses the same `AgentRunner` interface.  
+>    - Accepts `message`, `history`, and `collectionId`.  
+>    - Uses the unified tool registry to register tools with the Agent SDK.  
+>    - Runs a single logical agent interaction corresponding to one `/api/agent/chat` call.  
+> 3. Map the Agent SDK’s responses back to the existing `AgentChatResult` shape (message, toolCalls, history, usage).  
+> 4. Wire the `AGENT_IMPLEMENTATION` config so that `agent-sdk` selects this new runner.  
+> 5. Add basic tests that run a few happy-path scenarios through both runner implementations and compare behaviour.  
+> 
+> Constraints:  
+> - Do not change the HTTP API.  
+> - Do not remove the messages-based implementation.  
+> - Keep the number of Agent SDK–specific abstractions small; favor direct usage of its recommended patterns.
+
+---
+
+### Phase D — Tools Expansion (RAG, Lifecycle, Repos, External)
+
+> **User Prompt (Phase D)**  
+> Phase: D — Tools Expansion.  
+> Objective: Extend the tool registry to cover core RAG operations, lifecycle management, repo ingestion/sync, and external MCP-based tools.  
+> 
+> 1. Read:  
+>    - `docs/agent-sdk/02_AGENT_SDK_BUILD_PLAN.md` (Phase D).  
+>    - `docs/new-phases/01_BUILD_PLAN.md` and `02_GITHUB_ISSUES.md`.  
+>    - `docs/new-phases/07_EXTENDED_TECH_STACK_AND_REPO_INGESTION_PLAN.md`.  
+> 2. For each tool described in the build plans (search, ingest, collections, documents, lifecycle, repos, external MCP), design:  
+>    - A clear `name`.  
+>    - A human-readable `description`.  
+>    - An `inputSchema` (consider zod or JSON schema).  
+>    - An `executor` that calls existing or new backend services.  
+> 3. Implement these tools incrementally, keeping each change small and well-tested.  
+> 4. Ensure tools are usable by **both** the messages-based runner and the Agent SDK runner through the unified registry.  
+> 
+> Constraints:  
+> - Prefer using existing services (search, ingest, repo operations) rather than inventing new ones.  
+> - Keep each tool focused; avoid mega-tools that do too many things.  
+> - Maintain backwards compatibility.
+
+---
+
+### Phase E — MCP Integration
+
+> **User Prompt (Phase E)**  
+> Phase: E — MCP Integration.  
+> Objective: Align Synthesis’s MCP servers and external MCP servers with the new tool design so the Agent SDK can call them via tools.  
+> 
+> 1. Read:  
+>    - `apps/mcp/src/index.ts`.  
+>    - `docs/new-phases/06_PHASE_15_17_STATUS_REPORT.md`.  
+>    - `docs/new-phases/07_EXTENDED_TECH_STACK_AND_REPO_INGESTION_PLAN.md`.  
+> 2. Inventory existing MCP tools and map them to the unified tool registry where feasible.  
+> 3. Design or refine MCP servers for:  
+>    - Synthesis itself.  
+>    - `@new-phases` (planning docs).  
+>    - Context7-like external docs.  
+> 4. Implement tool executors that call these MCP servers internally, presenting them to the agent as normal tools.  
+> 5. Keep the MCP protocol and server boundaries simple and focused on a few high-value operations.  
+> 
+> Constraints:  
+> - Avoid creating an overly generic "MCP router"; tools should encapsulate MCP usage.  
+> - Reuse common client logic where sensible, but avoid premature abstraction.
+
+---
+
+### Phase F — Dual-Mode Testing & Rollout
+
+> **User Prompt (Phase F)**  
+> Phase: F — Dual-Mode Testing & Rollout.  
+> Objective: Validate the Agent SDK implementation against the legacy implementation, then roll it out safely.  
+> 
+> 1. Add tests that exercise both `MessagesApiAgentRunner` and `AgentSdkAgentRunner` using the same scenarios:  
+>    - Basic Q&A with tools.  
+>    - Multi-step RAG queries.  
+>    - Repo/search/lifecycle-related tasks.  
+> 2. Allow some textual variation in responses but enforce that:  
+>    - The correct tools are used.  
+>    - The outcomes (e.g., docs added, queries executed) are equivalent.  
+> 3. Document a rollout plan (dev, staging, production) in `docs/agent-sdk/02_AGENT_SDK_BUILD_PLAN.md`.  
+> 4. Help configure environments to use `AGENT_IMPLEMENTATION=agent-sdk` in staging for a while.  
+> 
+> Constraints:  
+> - No breaking changes to public APIs.  
+> - Keep configuration simple (env vars, no complex feature flag systems).  
+> - Avoid over-engineering testing harnesses; focus on key flows.
+
+---
+
+### Usage Notes
+
+- These prompts are deliberately **structured but flexible**. You can adapt them as you learn more or as project needs change.
+- The guiding principles remain:  
+> Minimal abstractions, incremental change, strong tests, and clear boundaries between agent, tools, MCP, and core RAG services.

--- a/docs/desktop-app/00_DESKTOP_APP_OVERVIEW.md
+++ b/docs/desktop-app/00_DESKTOP_APP_OVERVIEW.md
@@ -1,0 +1,102 @@
+## Synthesis Desktop App — Overview
+
+**Version:** 1.0  
+**Date:** 2025-11-13
+
+---
+
+### Purpose
+
+This folder (`docs/desktop-app`) defines a **high-level plan** for creating a desktop version of Synthesis.
+
+The goals:
+
+- Provide a **desktop shell** for Synthesis so you can:
+  - Start/stop the Synthesis backend stack from a desktop UI.
+  - Use the existing web UI in a window without manually managing browser tabs and Docker commands.
+  - Optionally bundle services (DB, Ollama, etc.) or at least orchestrate them.
+- Keep the solution **simple and not over-engineered**:
+  - Reuse the existing web frontend and backend.
+  - Avoid duplicating logic already handled in the main repo.
+  - Treat the desktop app as a thin wrapper around the server + web UI.
+
+This is **planning only**; no implementation is done here.
+
+---
+
+### High-Level Approach
+
+We will treat Synthesis Desktop as:
+
+- A **separate app** that:
+  - Starts the Synthesis backend (via Docker or direct processes) on localhost.
+  - Hosts the web UI in a desktop window via a webview (Electron or Tauri).
+- A **thin client** around the existing architecture:
+  - All RAG logic, DB, and MCP servers remain in the existing Synthesis codebase.
+  - The desktop shell focuses on orchestration and UX.
+
+This avoids rewriting the RAG pipeline or backend and leverages what is already working.
+
+---
+
+### Recommended Strategy
+
+- Keep Synthesis as the **source of truth** in this repo (`synthesis` monorepo).
+- Create a **desktop shell app** that depends on Synthesis:
+  - Either in this repo as `apps/desktop` (monorepo approach), or
+  - In a new repo (e.g. `synthesis-desktop`) that treats Synthesis as a dependency.
+- Recommended (to avoid over-engineering and duplication):
+  - Use the **monorepo approach** and create `apps/desktop` in this repo.
+  - This keeps versions of server + desktop shell aligned at the same commit.
+
+GitHub workflow details and options are described in `03_DESKTOP_APP_REPO_AND_WORKFLOW.md`.
+
+---
+
+### Target User Experience
+
+For you (and future users), the desktop app should:
+
+- On first run:
+  - Guide the user through initial setup (install Docker or configure local Postgres/Ollama if used).
+  - Optionally check for `docker-compose` and prompt to start the stack.
+- On normal use:
+  - Provide buttons like **“Start Synthesis”**, **“Stop Synthesis”**, **“Open UI”**.
+  - Open the existing Synthesis web UI in a native window.
+- For advanced users:
+  - Show health/status of services (DB, server, MCP, Ollama, etc.) at a simple level.
+  - Expose basic logs/error messages.
+
+We do **not** want to rebuild all Synthesis UI in a native toolkit; we reuse the web app.
+
+---
+
+### Scope & Non-Goals
+
+**In scope:**
+
+- Desktop shell (Electron/Tauri) which:
+  - Manages the lifecycle of the Synthesis backend stack.
+  - Embeds the existing web UI.
+  - Provides minimal status/diagnostics.
+- CI/CD and GitHub strategy for building desktop binaries for major platforms.
+
+**Out of scope (for now):**
+
+- Deep OS-specific integrations (tray icons, global hotkeys, protocol handlers).
+- Complex multi-tenant or sync features.
+- Running Claude/LLM models locally (still handled by Synthesis backend / external providers).
+
+---
+
+### Documents in This Folder
+
+- `00_DESKTOP_APP_OVERVIEW.md` — this overview.
+- `01_DESKTOP_APP_ARCHITECTURE.md` — detailed architecture options and chosen design.
+- `02_DESKTOP_APP_BUILD_PLAN.md` — phased build plan and tasks for implementation.
+- `03_DESKTOP_APP_REPO_AND_WORKFLOW.md` — GitHub repository and workflow strategy.
+- `04_DESKTOP_APP_GITHUB_ISSUES.md` — proposed issues cross-referenced with phases.
+- `05_DESKTOP_APP_PHASE_PROMPTS.md` — prompts for implementation agents per phase.
+- `06_DESKTOP_APP_TECH_STACK.md` — recommended tech stack, versions, and tooling.
+
+These docs are meant to be used later when you (or an agent) are ready to actually build the desktop app.

--- a/docs/desktop-app/01_DESKTOP_APP_ARCHITECTURE.md
+++ b/docs/desktop-app/01_DESKTOP_APP_ARCHITECTURE.md
@@ -1,0 +1,160 @@
+## Synthesis Desktop App — Architecture
+
+**Version:** 1.0  
+**Date:** 2025-11-13
+
+---
+
+### 1. Design Goals
+
+- **Reuse existing Synthesis stack** (backend, DB, web UI, MCP).
+- **Minimal new logic**: the desktop app should be a thin wrapper around the existing HTTP/API and Docker workflows.
+- **Cross-platform**: Linux, macOS, Windows.
+- **Simple install & run** for you; scalable later if you share binaries with others.
+
+We explicitly do **not** want to:
+
+- Re-implement the UI or RAG logic in native frameworks.
+- Maintain multiple divergent codebases for Synthesis.
+
+---
+
+### 2. Architecture Options
+
+We consider two main patterns.
+
+#### Option A — Monorepo Desktop App (`apps/desktop`)
+
+- Desktop app lives **inside the existing Synthesis repo** as another app in the pnpm workspace:
+  - `apps/server` — Fastify backend.
+  - `apps/web` — React web UI.
+  - `apps/mcp` — MCP server.
+  - `apps/desktop` — new Electron/Tauri-based desktop shell.
+
+**Pros:**
+
+- Single repo and workspace: shared `pnpm-lock.yaml`, TypeScript config, and CI.
+- Desktop and server versions are implicitly aligned (same commit).
+- Easier to publish releases that combine backend/server images and desktop binaries.
+
+**Cons:**
+
+- Repo becomes slightly heavier, but you’re already using a monorepo.
+
+#### Option B — Separate Desktop Repo (`synthesis-desktop`)
+
+- Desktop app lives in a separate repo, depending on Synthesis via:
+  - Git submodule, or
+  - HTTP/Docker images.
+
+**Pros:**
+
+- Can have its own release cadence and contributors.
+
+**Cons:**
+
+- Extra complexity keeping Synthesis server versions in sync with the desktop version.
+- More duplication and cross-repo coordination.
+
+**Recommendation:** **Option A (Monorepo)** — add `apps/desktop` to the existing workspace. This matches your preference for not over-engineering.
+
+---
+
+### 3. Component Overview
+
+In the monorepo approach, the desktop system consists of:
+
+1. **Desktop Shell App (`apps/desktop`)**
+   - Built with a desktop framework (see tech stack doc):
+     - Likely **Electron** (Node + Chromium) or **Tauri** (Rust + WebView).
+   - Responsibilities:
+     - Start/stop the Synthesis backend stack (directly or via Docker).
+     - Display the existing web UI inside a browser window.
+     - Show minimal status (running/not running, ports, errors).
+
+2. **Synthesis Backend Stack**
+   - **Server**: `apps/server` (Fastify, Node). 
+   - **Web UI**: `apps/web` (React/Vite).
+   - **DB**: Postgres+pgvector (via Docker or local service).
+   - **Optional models**: Ollama, etc., as already configured.
+
+3. **Launch Orchestration**
+
+Two pragmatic approaches:
+
+- **Docker-first orchestration (simpler for distribution)**
+  - Desktop app shells out to `docker compose up` / `down` with the existing `docker-compose.yml`.
+  - Assumes user has Docker/Podman installed.
+
+- **Direct process orchestration (for local dev)**
+  - Desktop app spawns `pnpm dev` or equivalent for server/web, and ensures Postgres is running.
+  - More flexible for you during development; less ideal for wider distribution.
+
+**Recommendation:** Support **Docker-first** as the primary mode for end users; keep **direct process** mode as a dev convenience.
+
+---
+
+### 4. Runtime Flow
+
+1. User launches Synthesis Desktop.
+2. Desktop app checks prerequisites:
+   - Docker available? (if using Docker mode)
+   - Ports free? (e.g., 3333 for server, 5173 for web).
+3. When user clicks **“Start Synthesis”**:
+   - Desktop app runs `docker compose up` (or equivalent) for Synthesis services.
+   - Waits until the health checks pass (e.g., server responding on `/health`).
+4. When backend is ready:
+   - Desktop app opens a window pointing to `http://localhost:5173` (web UI) or a pre-bundled production build served by the backend.
+5. **Stop Synthesis**:
+   - Desktop app runs `docker compose down` or sends a shutdown signal to the processes.
+
+Throughout, the desktop app may poll simple status endpoints and show green/yellow/red indicators.
+
+---
+
+### 5. Desktop App Responsibilities vs Synthesis Responsibilities
+
+**Desktop app (new):**
+
+- Service orchestration UI (start/stop).
+- Basic environment checks.
+- Hosting the web UI.
+- Packaging (building installers/binaries).
+
+**Synthesis (existing):**
+
+- All RAG logic and APIs.
+- Agents, tools, and MCP servers.
+- Data storage and search.
+- Web UI capabilities.
+
+This separation ensures you don’t double-implement features.
+
+---
+
+### 6. Deployment Targets & Binaries
+
+Target platforms (initially):
+
+- Linux (your current environment + broader desktop users).
+- macOS (if you want to share with others).
+- Windows (if desired; Tauri/Electron both support it).
+
+Basic plan:
+
+- Use the desktop framework’s tooling (Electron Builder / Tauri bundler) to create:
+  - `.AppImage` or `.deb` for Linux.
+  - `.dmg`/`.pkg` for macOS.
+  - `.exe`/installer for Windows.
+
+CI/CD details and GitHub workflow are described in `03_DESKTOP_APP_REPO_AND_WORKFLOW.md`.
+
+---
+
+### 7. Non-Goals and Constraints
+
+- **No complex plugin system** inside the desktop app.
+- **No duplicate configuration** (env vars should be shared or passed through to the server where possible).
+- **No monolithic binary that embeds DB + models** on day one — that would be over-engineered and heavy.
+
+The desktop app should remain a **convenience wrapper**, not a new platform.

--- a/docs/desktop-app/02_DESKTOP_APP_BUILD_PLAN.md
+++ b/docs/desktop-app/02_DESKTOP_APP_BUILD_PLAN.md
@@ -1,0 +1,177 @@
+## Synthesis Desktop App — Build Plan
+
+**Version:** 1.0  
+**Date:** 2025-11-13
+
+---
+
+### Overview
+
+This document lays out a **phased build plan** for the Synthesis Desktop app, assuming the architecture chosen in `01_DESKTOP_APP_ARCHITECTURE.md` (monorepo, `apps/desktop`, thin wrapper around existing stack).
+
+Each phase is designed to be small and focused to avoid over-engineering.
+
+---
+
+### Phase 1 — Desktop Shell Scaffolding
+
+**Goal:** Create a minimal desktop app that can open a window pointing at the existing Synthesis web UI.
+
+**Tasks:**
+
+1. **Scaffold `apps/desktop`**
+   - Add a new app under pnpm workspace: `apps/desktop`.
+   - Choose desktop framework (see `06_DESKTOP_APP_TECH_STACK.md`):
+     - Likely **Electron + TypeScript** initially, to stay close to existing Node/TS tooling.
+   - Add basic scripts:
+     - `pnpm --filter @synthesis/desktop dev`
+     - `pnpm --filter @synthesis/desktop build`
+
+2. **Minimal window open**
+   - Implement a main process that:
+     - Creates a single window.
+     - Loads a configurable URL (e.g., `http://localhost:5173`).
+
+3. **Configuration**
+   - Read base URL from env (e.g., `SYNTHESIS_URL=http://localhost:5173`).
+
+**Exit Criteria:**
+
+- Running `pnpm --filter @synthesis/desktop dev` opens a desktop window pointed at the, already-running, Synthesis web UI.
+
+---
+
+### Phase 2 — Service Orchestration (Docker-first)
+
+**Goal:** Let the desktop app start/stop the Synthesis backend via Docker.
+
+**Tasks:**
+
+1. **Prerequisite checks**
+   - From the desktop app, detect whether Docker is installed and running.
+   - Provide clear error messaging if not available.
+
+2. **Start/stop commands**
+   - Wire UI buttons to shell out to:
+     - `docker compose up -d` (using the repo’s `docker-compose.yml`).
+     - `docker compose down`.
+   - Optionally allow configuration of the Docker command for users with Podman or alternative setups.
+
+3. **Health checks**
+   - Implement simple checks (HTTP requests) to:
+     - `http://localhost:3333/health` (or equivalent) for the server.
+     - Optionally `http://localhost:5173` for the frontend.
+   - Display basic status in the UI: starting, running, error.
+
+**Exit Criteria:**
+
+- User can click “Start Synthesis” and the desktop app will:
+  - Run Docker compose.
+  - Wait for health checks to pass.
+  - Open the web UI when ready.
+- User can click “Stop Synthesis” and the app will bring down the stack.
+
+---
+
+### Phase 3 — Direct Process Mode (Dev Convenience)
+
+**Goal:** Support a mode for you as a developer to run Synthesis without Docker via the desktop app.
+
+**Tasks:**
+
+1. **Mode selection**
+   - Config flag (env or UI) to choose between **Docker mode** and **Direct process mode**.
+
+2. **Process spawning**
+   - In direct mode, spawn:
+     - `pnpm --filter @synthesis/server dev` (or equivalent).
+     - `pnpm --filter @synthesis/web dev`.
+   - Monitor stdout/stderr and surface basic logs/errors.
+
+3. **Shutdown**
+   - Ensure processes are terminated cleanly when the desktop app exits or when the user clicks “Stop Synthesis”.
+
+**Exit Criteria:**
+
+- In dev mode, a single start in the desktop app can launch the server and web dev servers.
+- Clean shutdown works reliably.
+
+---
+
+### Phase 4 — Status, Logs, and UX Polish
+
+**Goal:** Improve the desktop UX with status indicators and basic diagnostics.
+
+**Tasks:**
+
+1. **Status indicators**
+   - Show per-service status: DB, server, web, MCP, models (if possible).
+   - Keep this simple: green/amber/red, plus short text messages.
+
+2. **Logs**
+   - Provide an optional panel or view where recent logs (or error summaries) are shown.
+   - Focus on: startup failures, port conflicts, Docker errors.
+
+3. **Error handling**
+   - Gracefully handle cases where:
+     - Ports are already in use.
+     - Services crash after startup.
+
+**Exit Criteria:**
+
+- User can understand at a glance whether Synthesis is healthy from the desktop UI.
+- Common errors are surfaced in a human-readable way.
+
+---
+
+### Phase 5 — Packaging & Distribution
+
+**Goal:** Build distributable binaries/installers for major platforms.
+
+**Tasks:**
+
+1. **Build configuration**
+   - Use Electron Builder (or equivalent) to configure packaging for:
+     - Linux (AppImage or `.deb`).
+     - macOS (`.dmg`/`.pkg`).
+     - Windows (`.exe`/installer).
+
+2. **Environment and config**
+   - Ensure the desktop app can find:
+     - The repo’s `docker-compose.yml`.
+     - Default ports and URLs.
+   - Decide how to handle config per environment (dev vs packaged release).
+
+3. **GitHub Actions CI**
+   - Add workflows to:
+     - Build desktop packages on tagged releases.
+     - Attach artifacts to GitHub releases.
+
+**Exit Criteria:**
+
+- Simple installable artifacts exist for at least Linux and macOS.
+- CI can produce these artifacts on demand.
+
+---
+
+### Phase 6 — Optional Enhancements
+
+**Goal:** Add quality-of-life features as needed, without over-engineering.
+
+Possible tasks (only if they provide clear value):
+
+- Auto-update checks for new desktop versions.
+- Quick links to open Synthesis docs, logs, and config.
+- Basic configuration editor for Synthesis env vars (write `.env.local` or similar).
+
+---
+
+### Summary
+
+This build plan keeps the Synthesis Desktop app **very thin**:
+
+- It orchestrates Docker or dev processes.
+- It reuses the existing web UI and backend.
+- It avoids duplicating RAG or agent logic.
+
+A future implementation agent can follow this plan phase by phase, using `05_DESKTOP_APP_PHASE_PROMPTS.md` for scoped instructions and `04_DESKTOP_APP_GITHUB_ISSUES.md` to create tracking issues in GitHub.

--- a/docs/desktop-app/03_DESKTOP_APP_REPO_AND_WORKFLOW.md
+++ b/docs/desktop-app/03_DESKTOP_APP_REPO_AND_WORKFLOW.md
@@ -120,7 +120,7 @@ For you / contributors:
 3. For desktop development:
    - Run `pnpm install`.
    - Run `pnpm --filter @synthesis/desktop dev` (and ensure server/web/DB are running via Docker or direct commands).
-4. For full stack testing:
+4. For full-stack testing:
    - Use existing commands for server/web/MCP.
    - Use desktop app to orchestrate stack as a sanity check.
 

--- a/docs/desktop-app/03_DESKTOP_APP_REPO_AND_WORKFLOW.md
+++ b/docs/desktop-app/03_DESKTOP_APP_REPO_AND_WORKFLOW.md
@@ -1,0 +1,148 @@
+## Synthesis Desktop App — Repo & Workflow Strategy
+
+**Version:** 1.0  
+**Date:** 2025-11-13
+
+---
+
+### 1. Repository Strategy
+
+We want a strategy that:
+
+- Keeps Synthesis as the **single source of truth** for backend + web.
+- Minimizes duplication between web/server and desktop.
+- Works well with your existing pnpm monorepo.
+
+#### Recommended: Monorepo with `apps/desktop`
+
+- Keep everything in this repo and add:
+  - `apps/desktop` for the desktop shell.
+- Use the existing pnpm workspace (`pnpm-workspace.yaml`) to manage dependencies.
+
+**Advantages:**
+
+- One repo = easier mental model.
+- Desktop app and server always at compatible versions (same commit).
+- CI can build server, web, MCP, and desktop in one place.
+
+#### Alternative: New Repo `synthesis-desktop`
+
+You could also create a separate repo:
+
+- `synthesis-desktop` that depends on:
+  - Docker images published from the main Synthesis repo, or
+  - Git submodule/remote of Synthesis.
+
+**Trade-offs:**
+
+- Slightly cleaner separation of concerns for contributors.
+- But more complex versioning and cross-repo maintenance.
+
+**Conclusion:** For now, **monorepo with `apps/desktop` is recommended** to avoid over-engineering and dual-maintenance.
+
+---
+
+### 2. Branching & Release Workflow
+
+#### Branches
+
+- **`main`**: stable Synthesis (server/web/MCP) + optionally stable desktop.
+- **`develop` or feature branches**: new desktop features (`desktop-init`, `desktop-orchestration`, etc.).
+- **`agent-sdk`**: as already planned, used for Agent SDK migration on the server side.
+
+Desktop work can be done on dedicated feature branches and merged into `main` once stable.
+
+#### Releases
+
+- Use **Git tags** and GitHub Releases to manage versions.
+- Suggested version alignment:
+  - Synthesis server/web: `v2.0.x`.
+  - Desktop: `v2.0.x-desktop.y` or keep same version if you release them together.
+
+Distribution strategy:
+
+- On a tagged desktop-related release:
+  - Build desktop binaries via CI (see build plan).
+  - Attach them as assets to the GitHub release.
+
+---
+
+### 3. CI/CD Workflow (High Level)
+
+Assuming GitHub Actions:
+
+1. **Build & Test Workflow** (on PRs and main pushes):
+   - Steps:
+     - Install Node (LTS) and pnpm.
+     - `pnpm install`.
+     - `pnpm lint`, `pnpm test`, `pnpm typecheck` for server/web.
+     - `pnpm --filter @synthesis/desktop test` (once desktop has tests).
+
+2. **Release Workflow** (on tags like `v2.0.0-desktop.0`):
+   - Steps:
+     - Build server/web as usual (if desired for container publish).
+     - Build desktop app for target platforms.
+     - Upload artifacts to the GitHub release.
+
+**Note:** We don’t need a very complex CI initially; just enough to build and test the desktop app alongside the existing services.
+
+---
+
+### 4. GitHub Project Organization
+
+To keep things clear for contributors and your future self:
+
+- Create a **GitHub Project board** (optional) for "Synthesis Desktop".
+- Use labels like:
+  - `desktop-app`
+  - `electron` (or `tauri`), depending on chosen stack.
+  - `priority:high`, `priority:medium`, `priority:low`.
+
+Group issues by phases defined in `02_DESKTOP_APP_BUILD_PLAN.md`:
+
+- Phase 1: Scaffolding
+- Phase 2: Orchestration (Docker)
+- Phase 3: Direct Process mode
+- Phase 4: Status & Logs
+- Phase 5: Packaging
+- Phase 6: Optional enhancements
+
+Cross-reference issues in `04_DESKTOP_APP_GITHUB_ISSUES.md` with these phases.
+
+---
+
+### 5. Developer Workflow Summary
+
+For you / contributors:
+
+1. Clone the repo.
+2. Install Node LTS and pnpm.
+3. For desktop development:
+   - Run `pnpm install`.
+   - Run `pnpm --filter @synthesis/desktop dev` (and ensure server/web/DB are running via Docker or direct commands).
+4. For full stack testing:
+   - Use existing commands for server/web/MCP.
+   - Use desktop app to orchestrate stack as a sanity check.
+
+This keeps the workflow consistent with how you already work on Synthesis, avoiding a separate "desktop-only" dev story.
+
+---
+
+### 6. Future Scaling Options (Optional)
+
+If the desktop app becomes popular and needs more independence:
+
+- You could later:
+  - Split it into its own repo if that simplifies onboarding for desktop-only contributors.
+  - Consume Synthesis via Docker images or published artifacts.
+
+But at the current stage, co-locating everything in one repo is simpler and avoids premature optimisation.
+
+---
+
+### Summary
+
+- **Monorepo with `apps/desktop` is recommended** for simplicity and alignment.
+- Branches and CI can follow your existing patterns.
+- Desktop app releases can be tied to or versioned alongside Synthesis server/web releases.
+- The workflow stays close to what you already do: build, test, and run everything from one place.

--- a/docs/desktop-app/04_DESKTOP_APP_GITHUB_ISSUES.md
+++ b/docs/desktop-app/04_DESKTOP_APP_GITHUB_ISSUES.md
@@ -1,0 +1,156 @@
+## Synthesis Desktop App — Proposed GitHub Issues
+
+**Version:** 1.0  
+**Date:** 2025-11-13
+
+---
+
+### Overview
+
+This document defines **issue templates** for building the Synthesis Desktop app, cross-referenced with phases from `02_DESKTOP_APP_BUILD_PLAN.md`.
+
+Suggested labels:
+
+- `desktop-app`
+- `electron` (or `tauri`, once chosen)
+- `feature`
+- `refactor`
+- `priority:high` / `priority:medium` / `priority:low`
+
+Milestone name (example):
+
+- `Milestone: Synthesis Desktop v1`
+
+---
+
+### Phase 1 — Desktop Shell Scaffolding
+
+**Issue 1:** `feat(desktop): Scaffold apps/desktop and basic window`
+
+- **Phase:** 1 (Scaffolding)
+- **Labels:** `desktop-app`, `feature`, `priority:high`
+- **Description:**
+  - Create the `apps/desktop` app in the pnpm workspace.
+  - Set up the chosen desktop framework.
+  - Implement a main process that opens a window pointing at a configurable URL (Synthesis web UI).
+- **Acceptance Criteria:**
+  - [ ] `apps/desktop` exists and builds.
+  - [ ] `pnpm --filter @synthesis/desktop dev` opens a window.
+  - [ ] The window points at `SYNTHESIS_URL` (e.g., `http://localhost:5173`).
+
+**Cross-References:**
+
+- `docs/desktop-app/02_DESKTOP_APP_BUILD_PLAN.md` — Phase 1.
+- `docs/desktop-app/06_DESKTOP_APP_TECH_STACK.md` — tech choices.
+
+---
+
+### Phase 2 — Service Orchestration (Docker-first)
+
+**Issue 2:** `feat(desktop): Add Docker-based start/stop controls`
+
+- **Phase:** 2 (Orchestration — Docker)
+- **Labels:** `desktop-app`, `feature`, `priority:high`
+- **Description:**
+  - Add UI controls to start/stop Synthesis via Docker.
+  - Shell out to `docker compose up -d` and `docker compose down` using the repo’s `docker-compose.yml`.
+  - Implement basic health checks to confirm when services are ready.
+- **Acceptance Criteria:**
+  - [ ] "Start Synthesis" and "Stop Synthesis" buttons exist.
+  - [ ] Starting triggers Docker compose and waits for server health to be green.
+  - [ ] Stopping tears down the stack cleanly.
+
+**Cross-References:**
+
+- `docs/desktop-app/02_DESKTOP_APP_BUILD_PLAN.md` — Phase 2.
+- `docs/desktop-app/01_DESKTOP_APP_ARCHITECTURE.md` — runtime flow.
+
+---
+
+### Phase 3 — Direct Process Mode (Dev Convenience)
+
+**Issue 3:** `feat(desktop): Implement direct process mode for dev`
+
+- **Phase:** 3 (Direct process mode)
+- **Labels:** `desktop-app`, `feature`, `priority:medium`
+- **Description:**
+  - Add a mode that spawns the Synthesis server and web dev servers directly (without Docker).
+  - Allow switching between Docker and direct modes via config.
+- **Acceptance Criteria:**
+  - [ ] A config flag selects Docker vs direct mode.
+  - [ ] In direct mode, server and web dev processes are spawned and monitored.
+  - [ ] Processes are shut down cleanly when stopping.
+
+**Cross-References:**
+
+- `docs/desktop-app/02_DESKTOP_APP_BUILD_PLAN.md` — Phase 3.
+
+---
+
+### Phase 4 — Status, Logs, and UX Polish
+
+**Issue 4:** `feat(desktop): Display service status and basic logs`
+
+- **Phase:** 4 (Status & Logs)
+- **Labels:** `desktop-app`, `feature`, `priority:medium`
+- **Description:**
+  - Show simple status indicators (running/starting/error) for key services.
+  - Provide a log view or panel for recent errors and warnings.
+- **Acceptance Criteria:**
+  - [ ] Per-service status indicators are visible.
+  - [ ] Log output or error summaries can be viewed.
+  - [ ] Common failures (port conflict, Docker not available) are clearly communicated.
+
+**Cross-References:**
+
+- `docs/desktop-app/02_DESKTOP_APP_BUILD_PLAN.md` — Phase 4.
+
+---
+
+### Phase 5 — Packaging & Distribution
+
+**Issue 5:** `feat(desktop): Configure packaging for desktop binaries`
+
+- **Phase:** 5 (Packaging)
+- **Labels:** `desktop-app`, `feature`, `priority:medium`
+- **Description:**
+  - Set up build configuration for producing installable artifacts on Linux and macOS (and optionally Windows).
+  - Add CI workflow(s) to build these artifacts on tagged releases.
+- **Acceptance Criteria:**
+  - [ ] `pnpm --filter @synthesis/desktop build` produces platform-specific binaries.
+  - [ ] GitHub Actions workflow builds desktop artifacts on tag push.
+  - [ ] Release notes clearly mention the desktop version.
+
+**Cross-References:**
+
+- `docs/desktop-app/02_DESKTOP_APP_BUILD_PLAN.md` — Phase 5.
+- `docs/desktop-app/03_DESKTOP_APP_REPO_AND_WORKFLOW.md` — release workflow.
+
+---
+
+### Phase 6 — Optional Enhancements
+
+**Issue 6:** `feat(desktop): Add quality-of-life features`
+
+- **Phase:** 6 (Optional Enhancements)
+- **Labels:** `desktop-app`, `feature`, `priority:low`
+- **Description:**
+  - Add optional features such as:
+    - Auto-update checks.
+    - Quick links to logs, docs, and config.
+    - Simple UI for editing key Synthesis env vars.
+- **Acceptance Criteria (examples, not all required at once):**
+  - [ ] At least one high-value enhancement is implemented.
+  - [ ] Features are behind configuration flags if they add complexity.
+
+**Cross-References:**
+
+- `docs/desktop-app/02_DESKTOP_APP_BUILD_PLAN.md` — Phase 6.
+
+---
+
+### Summary
+
+- Each issue is intentionally scoped to a single phase or feature.
+- Issues are cross-referenced with the build plan and other docs to make navigation easy for implementation agents.
+- You can copy these templates into GitHub when you’re ready to start actual implementation work on the Synthesis Desktop app.

--- a/docs/desktop-app/05_DESKTOP_APP_PHASE_PROMPTS.md
+++ b/docs/desktop-app/05_DESKTOP_APP_PHASE_PROMPTS.md
@@ -1,0 +1,148 @@
+## Synthesis Desktop App — Phase Prompts for Implementation Agents
+
+**Version:** 1.0  
+**Date:** 2025-11-13
+
+---
+
+### General System Prompt
+
+> **System Prompt (Desktop App)**  
+> You are an experienced full-stack engineer working on the Synthesis project.  
+> Synthesis is a RAG system with a Fastify backend, React frontend, PostgreSQL/pgvector, and MCP integrations.  
+> Your task in this phase is to implement part of the Synthesis Desktop app, which is a thin wrapper around the existing Synthesis stack.  
+> You must follow the design and constraints in `docs/desktop-app/*` and the existing architecture docs.  
+> Do not over-engineer: prefer small, incremental changes.  
+> Reuse existing code and workflows wherever possible.  
+> Do not duplicate RAG logic or UI in native code; use the existing server and web UI.  
+> When in doubt, document trade-offs and choose the simplest workable approach.
+
+You can combine this system prompt with the phase-specific user prompts below.
+
+---
+
+### Phase 1 — Desktop Shell Scaffolding
+
+> **User Prompt (Phase 1)**  
+> Phase: 1 — Desktop Shell Scaffolding.  
+> Objective: Create `apps/desktop` and a minimal desktop app that opens a window pointing to the Synthesis web UI.  
+> 
+> 1. Read:  
+>    - `docs/desktop-app/00_DESKTOP_APP_OVERVIEW.md`  
+>    - `docs/desktop-app/01_DESKTOP_APP_ARCHITECTURE.md`  
+>    - `docs/desktop-app/06_DESKTOP_APP_TECH_STACK.md` (for framework choice).  
+> 2. Scaffold `apps/desktop` as a new app in the pnpm workspace using the chosen framework (Electron or Tauri).  
+> 3. Implement a main process that opens a single window pointing at a configurable `SYNTHESIS_URL` (e.g., `http://localhost:5173`).  
+> 4. Add minimal scripts to run the desktop app in dev mode.  
+> 5. Do not implement orchestration or complex UI yet; focus on proving that the desktop shell can host the web UI.  
+> 
+> Constraints:  
+> - No changes to the Synthesis backend or web app.  
+> - Keep dependencies minimal.  
+> - Ensure the app builds and runs on your primary dev OS.
+
+---
+
+### Phase 2 — Service Orchestration (Docker-first)
+
+> **User Prompt (Phase 2)**  
+> Phase: 2 — Service Orchestration (Docker-first).  
+> Objective: Allow the desktop app to start and stop the Synthesis backend via Docker.  
+> 
+> 1. Read:  
+>    - `docs/desktop-app/01_DESKTOP_APP_ARCHITECTURE.md` (runtime flow).  
+>    - `docs/desktop-app/02_DESKTOP_APP_BUILD_PLAN.md` (Phase 2).  
+> 2. Implement checks for Docker availability and show friendly errors if not present.  
+> 3. Add “Start Synthesis” and “Stop Synthesis” controls that:  
+>    - Run `docker compose up -d` using the repo’s `docker-compose.yml`.  
+>    - Run `docker compose down` to stop services.  
+> 4. Implement simple health checks (HTTP) to wait for the server to be ready before opening the web UI.  
+> 5. Keep logging simple: show a short status or toast when starting/stopping.  
+> 
+> Constraints:  
+> - Do not introduce a complex process manager; shelling out is acceptable.  
+> - Focus on Docker mode; direct process mode will be added later.  
+> - Fail gracefully if Docker is missing.
+
+---
+
+### Phase 3 — Direct Process Mode (Dev Convenience)
+
+> **User Prompt (Phase 3)**  
+> Phase: 3 — Direct Process Mode.  
+> Objective: Add a developer-only mode that runs the Synthesis server and web dev servers directly (without Docker).  
+> 
+> 1. Read:  
+>    - `docs/desktop-app/02_DESKTOP_APP_BUILD_PLAN.md` (Phase 3).  
+> 2. Add configuration to choose between Docker mode and direct process mode (env or simple UI toggle).  
+> 3. In direct mode, spawn the Node processes for server and web dev (e.g., `pnpm --filter @synthesis/server dev` and `pnpm --filter @synthesis/web dev`).  
+> 4. Ensure processes are monitored and terminated cleanly on stop/exit.  
+> 5. Keep logs minimal but accessible if needed for debugging.  
+> 
+> Constraints:  
+> - Direct mode is optional and mainly for you as the developer; it’s okay if Docker remains the recommended path for others.  
+> - Avoid complicated process supervision frameworks; basic spawn/kill is acceptable.
+
+---
+
+### Phase 4 — Status, Logs, and UX Polish
+
+> **User Prompt (Phase 4)**  
+> Phase: 4 — Status, Logs, and UX Polish.  
+> Objective: Improve the desktop UX with clear service status indicators and basic log display.  
+> 
+> 1. Read:  
+>    - `docs/desktop-app/02_DESKTOP_APP_BUILD_PLAN.md` (Phase 4).  
+> 2. Implement visual indicators for the status of core services (server, web, DB, MCP if possible).  
+> 3. Surface common errors (Docker unavailable, port conflicts, health check failures) with human-readable messages.  
+> 4. Add a simple log or “recent events” view that shows key startup/shutdown messages, not a full log viewer.  
+> 
+> Constraints:  
+> - Keep UI minimal and clean.  
+> - Don’t build a full log management tool; just enough to debug common issues.
+
+---
+
+### Phase 5 — Packaging & Distribution
+
+> **User Prompt (Phase 5)**  
+> Phase: 5 — Packaging & Distribution.  
+> Objective: Configure packaging and CI for building installable desktop binaries.  
+> 
+> 1. Read:  
+>    - `docs/desktop-app/02_DESKTOP_APP_BUILD_PLAN.md` (Phase 5).  
+>    - `docs/desktop-app/03_DESKTOP_APP_REPO_AND_WORKFLOW.md`.  
+> 2. Configure packaging (Electron Builder or equivalent) for at least Linux and macOS.  
+> 3. Integrate this into a GitHub Actions workflow that builds artifacts on tagged releases.  
+> 4. Ensure versioning aligns with Synthesis server/web releases or has a clear mapping.  
+> 
+> Constraints:  
+> - Start with a minimal set of targets; you can add Windows later.  
+> - Avoid overly complex release automation; a straightforward “build on tag” workflow is enough.
+
+---
+
+### Phase 6 — Optional Enhancements
+
+> **User Prompt (Phase 6)**  
+> Phase: 6 — Optional Enhancements.  
+> Objective: Add one or more quality-of-life features that make the desktop app more pleasant to use, without major complexity.  
+> 
+> 1. Review the optional enhancement ideas in `docs/desktop-app/02_DESKTOP_APP_BUILD_PLAN.md`.  
+> 2. Pick one high-value feature (e.g., auto-update checks, quick links to logs/docs, simple env var editor).  
+> 3. Design and implement it in a way that’s easy to disable or extend later.  
+> 4. Update documentation and, if needed, GitHub issues to reflect the new capability.  
+> 
+> Constraints:  
+> - Keep each enhancement small.  
+> - Avoid features that significantly expand scope (e.g., complex settings UIs, user management).
+
+---
+
+### Summary
+
+These prompts give you a **structured way** to guide future implementation agents through the desktop app work:
+
+- Each phase has a clear objective, references, and constraints.
+- The system prompt enforces the “thin wrapper, no over-engineering” philosophy.
+- As with the Agent SDK docs, these can be copied directly into an agent’s instructions when you’re ready to build.

--- a/docs/desktop-app/06_DESKTOP_APP_TECH_STACK.md
+++ b/docs/desktop-app/06_DESKTOP_APP_TECH_STACK.md
@@ -1,0 +1,122 @@
+## Synthesis Desktop App — Tech Stack & Versions
+
+**Version:** 1.0  
+**Date:** 2025-11-13
+
+---
+
+### 1. Goals for the Tech Stack
+
+- Align with the existing Synthesis stack where possible.
+- Use **stable, well-supported tools** with good ecosystem support.
+- Avoid introducing heavy or exotic technologies that would over-complicate setup.
+
+---
+
+### 2. Core Choices
+
+#### 2.1 Node.js & Package Manager
+
+- **Node.js:** use the same LTS version as Synthesis:
+  - Recommended: **Node.js 20 LTS** (matches Anthropic TypeScript SDK’s supported runtimes and modern TS tooling) — see the `@anthropic-ai/sdk` README’s supported runtimes for Node 20 LTS guidance.
+- **Package manager:** `pnpm` (already in use in this repo).
+- **Version management:**
+  - Keep `.nvmrc` pointing to Node 20 LTS.
+  - Use `pnpm-lock.yaml` for reproducible installs.
+
+#### 2.2 Desktop Framework
+
+Two realistic options that work well with your existing TypeScript/React experience:
+
+- **Option A: Electron + TypeScript** (recommended starting point)
+  - Pros:
+    - Very mature ecosystem and tooling.
+    - Pure JS/TS stack; no Rust/C++ needed.
+    - Easy integration with Node/Pnpm monorepo.
+  - Cons:
+    - Heavier runtime (bundled Chromium).
+
+- **Option B: Tauri + TypeScript**
+  - Pros:
+    - Lightweight bundle; uses system webview.
+    - Good security model.
+  - Cons:
+    - Requires Rust toolchain.
+    - Slightly more complex initial setup if you’re not already using Rust.
+
+**Recommendation:** Start with **Electron + TypeScript** for the first version of Synthesis Desktop to keep everything in the TypeScript/Node ecosystem.
+
+#### 2.3 UI Layer
+
+- The desktop app will mostly:
+  - Use Electron’s main process to orchestrate services.
+  - Use a minimal renderer (front-end) for:
+    - Start/stop buttons.
+    - Status indicators.
+    - Basic logs.
+- The main **RAG UI** remains the existing Synthesis web frontend (React/Vite), loaded inside a webview.
+
+---
+
+### 3. Suggested Versions (Initial Baseline)
+
+> Note: These are starting points; you can adjust to the latest stable LTS at the time you implement.
+
+- **Node.js:** 20.x LTS (e.g., `20.18.0`).
+- **pnpm:** 9.x (matching current repo tooling).
+- **Electron:** latest stable major at the time of implementation (e.g., ~`31.x`+). When you start, pick the then-current stable and record it here.
+- **TypeScript:** follow repo-wide version (already in `pnpm-lock.yaml`).
+
+You do not need additional frontend frameworks inside the desktop app beyond minimal UI components; reusing the Synthesis web UI is the priority.
+
+---
+
+### 4. Tooling & Configuration
+
+#### 4.1 Node & pnpm
+
+- Use existing `nvm` + `.nvmrc` to pin Node version.
+- Run `pnpm install` at repo root; desktop app will be part of the workspace.
+
+#### 4.2 Electron Config
+
+- Basic config files:
+  - `apps/desktop/package.json` with scripts (`dev`, `build`).
+  - Main process entry file (`main.ts` or `main.js`).
+  - Electron Builder config (if used) for packaging.
+
+- Favor simple, well-documented defaults; avoid advanced Electron features unless needed.
+
+---
+
+### 5. External Dependencies
+
+The desktop app relies on external services rather than embedding everything:
+
+- **Docker** (for production-style local runs):
+  - Use existing `docker-compose.yml` from the Synthesis repo.
+- **Local Postgres/Ollama/etc.** (optional):
+  - For dev mode, you may rely on local services instead of Docker.
+
+We do **not** plan to embed Postgres or Ollama in the desktop binary in the first version.
+
+---
+
+### 6. Best Practices & Non-Goals
+
+- **Best practices:**
+  - Keep dependency list short; avoid pulling in large UI kits just for status indicators.
+  - Use TypeScript for type safety, consistent with the rest of the repo.
+  - Keep all environment-specific configuration in `.env` files or Electron’s config rather than hardcoding paths.
+
+- **Non-goals:**
+  - No native OS-specific UI beyond what is truly needed.
+  - No complex plugin/add-on system for the desktop app.
+  - No bundling of heavy, long-running services inside the desktop binary itself.
+
+---
+
+### Summary
+
+- The desktop app tech stack should mirror Synthesis where possible: Node 20 LTS, TypeScript, pnpm, and a simple Electron wrapper.
+- This keeps the learning curve low, leverages existing tooling, and avoids over-engineering while still giving you a convenient way to run and manage Synthesis locally.

--- a/docs/new-phases/00_PHASE_16_OVERVIEW.md
+++ b/docs/new-phases/00_PHASE_16_OVERVIEW.md
@@ -1,0 +1,12 @@
+# Phase 16: Feature Completion & Hardening
+
+**Objective:** This phase addresses critical missing features and completes the MCP server to make the Synthesis platform feature-complete, robust, and ready for wider use.
+
+The work is broken down into four main parts:
+
+1.  **MCP Server Completion:** Implement the remaining management tools and conduct a security review to provide a complete and secure agent interface to the RAG system.
+2.  **UI/UX Enhancements:** Add highly-requested user features such as creating collections and batch deleting documents directly from the user interface.
+3.  **Persistent Chat History:** Implement a full-stack solution to save and load chat sessions, providing memory and continuity for users.
+4.  **Document Lifecycle Management:** Add features to view, edit, and update existing documents to ensure the knowledge base remains current.
+
+This phase will transition the project from a functional prototype to a more mature and user-friendly application.

--- a/docs/new-phases/01_BUILD_PLAN.md
+++ b/docs/new-phases/01_BUILD_PLAN.md
@@ -1,0 +1,157 @@
+# Phase 16: Build Plan
+
+**Focus:** MCP Server Completion, UI/UX Enhancements, Persistent Chat History
+
+---
+
+## Part 1 — MCP Server Completion & Hardening
+
+**Goal:** Implement all planned MCP tools and secure the server.
+
+### 1.1: Implement Missing Management Tools (4-5 hours)
+
+**File to Modify:** `apps/mcp/src/index.ts`
+
+For each tool below, implement the `server.registerTool` function, create a Zod schema for input validation, and connect it to the corresponding backend API endpoint using the `apiClient`.
+
+1.  **`list_collections`**
+    *   **Description:** Lists all available document collections.
+    *   **Input:** None.
+    *   **Action:** Call `apiClient.get('/api/collections')`.
+
+2.  **`list_documents`**
+    *   **Description:** Lists all documents within a given collection.
+    *   **Input:** `z.object({ collectionId: z.string().uuid() })`
+    *   **Action:** Call `apiClient.get("/api/collections/${collectionId}/documents")`.
+
+3.  **`create_collection`**
+    *   **Description:** Creates a new, empty collection.
+    *   **Input:** `z.object({ name: z.string().min(1), description: z.string().optional() })`
+    *   **Action:** Call `apiClient.post('/api/collections', { name, description })`.
+
+4.  **`fetch_and_add_document_from_url`**
+    *   **Description:** Fetches content from a URL and ingests it.
+    *   **Input:** `z.object({ collectionId: z.string().uuid(), url: z.string().url() })`
+    *   **Action:** Call `apiClient.post('/api/documents/add-from-url', { collectionId, url })`.
+
+5.  **`delete_document`**
+    *   **Description:** Deletes a single document.
+    *   **Input:** `z.object({ documentId: z.string().uuid(), confirm: z.literal(true) })`
+    *   **Action:** Call `apiClient.delete("/api/documents/${documentId}")`.
+
+6.  **`delete_collection`**
+    *   **Description:** Deletes an entire collection and all its documents.
+    *   **Input:** `z.object({ collectionId: z.string().uuid(), confirm: z.literal(true) })`
+    *   **Action:** Call `apiClient.delete("/api/collections/${collectionId}")`.
+
+### 1.2: MCP Server Security Hardening (2-3 hours)
+
+1.  **Add Rate Limiting:** Implement a token-bucket limiter at the HTTP transport layer with a default refill rate of 100 tokens/minute and a burst capacity of 200 tokens. Persist limiter state in an in-memory `Map` keyed by canonical client IP, where each entry tracks `tokens` + `lastRefill`. Resolve the IP by trusting the first public value in `X-Forwarded-For` when `trustProxy=true`, otherwise fall back to `req.ip`; document how to configure the trusted proxy list. Run a GC pass every 10 minutes to evict keys idle for 30 minutes so the map cannot grow unbounded. Provide a bypass list for requests that carry a valid `Authorization` header (authenticated users) and for internal service CIDRs, both configurable per environment. Expose knobs for refill rate, burst size, and bypass CIDRs via env or config. Call out that the in-memory option only works for single-instance deployments; for clustered deployments, recommend wiring up `express-rate-limit` or `rate-limiter-flexible` with Redis/Postgres storage so state, cleanup, and distributed coordination are handled automatically.
+2.  **Authentication (Future-proofing):** While not yet implemented in the backend, add placeholder logic in the MCP server to check for an `Authorization` header and pass it through to the `apiClient`. This makes it easier to secure later.
+3.  **Dependency Security Scan:** Run `pnpm audit` within the `apps/mcp` directory and report any high or critical vulnerabilities. Create a plan to mitigate them.
+4.  **Input Validation Review:** Ensure every tool uses a `.strict()` Zod schema to prevent any extra, unexpected parameters from being passed.
+
+---
+
+## Part 2 — UI/UX Enhancements
+
+**Goal:** Improve user workflow by adding key management features to the frontend.
+
+### 2.1: "Add New Collection" Feature (3-4 hours)
+
+1.  **Create Button:** In `apps/web/src/pages/CollectionView.tsx`, add a new "Add Collection" button to the UI.
+2.  **Create Modal:** Build a new reusable `Modal` component and a specific `AddCollectionModal.tsx` component. The modal should contain a form with "Name" and "Description" fields.
+3.  **API Integration:** On form submission, call a new backend endpoint `POST /api/collections` with the form data. Use React Query for mutation handling to automatically refetch the collections list on success.
+
+### 2.2: Batch Document Deletion (3-4 hours)
+
+1.  **Backend API Endpoint:**
+    *   Create a new endpoint: `DELETE /api/documents/batch`.
+    *   It should accept a body with an array of document IDs: `{ documentIds: [...] }`.
+    *   Implement the logic in `apps/server` to delete multiple documents in a single transaction.
+2.  **Frontend UI:**
+    *   In the document list view (`apps/web/src/pages/DocumentView.tsx`), add checkboxes next to each document.
+    *   When one or more documents are selected, show a "Delete Selected" button.
+    *   On click, show a confirmation dialog.
+    *   On confirmation, call the new `DELETE /api/documents/batch` endpoint and refetch the document list.
+
+---
+
+## Part 3 — Persistent Chat History
+
+**Goal:** Allow users to save and resume their chat sessions.
+
+### 3.1: Backend - Database & API (4-5 hours)
+
+1.  **Database Schema (`packages/db`):**
+    *   Create a `chat_sessions` table (`id`, `user_id`, `title`, `created_at`).
+    *   Create a `chat_messages` table (`id`, `session_id`, `role` ('user' or 'assistant'), `content`, `timestamp`).
+2.  **API Endpoints (`apps/server`):**
+    *   `GET /api/chats`: List all chat sessions for the current user.
+    *   `POST /api/chats`: Create a new chat session.
+    *   `GET /api/chats/:id/messages`: Get all messages for a specific chat session.
+    *   Modify the existing `/api/search` or a new `/api/chats/:id/message` endpoint to automatically save the user's prompt and the AI's response to the database.
+
+### 3.2: Frontend - UI & State Management (5-6 hours)
+
+1.  **Chat History Panel:**
+    *   Create a new collapsible sidebar component in `apps/web/src/pages/ChatPage.tsx`.
+    *   Fetch and display the list of past chat sessions from `GET /api/chats`.
+    *   Allow users to click a session to load it, or click a "New Chat" button.
+2.  **State Management:**
+    *   Use React Query to fetch and cache chat history.
+    *   When a user sends a message, use a mutation to save the message and the response.
+    *   The chat interface should be driven by the data from the API, not just local state.
+3.  **Routing:**
+    *   Update the routing to support URLs like `/chat/:id` to link directly to a specific chat session. If no ID is present, it can be a new chat.
+
+---
+
+## Part 4 — Document Lifecycle Management
+
+**Goal:** Add features to view, edit, and update existing documents to ensure the knowledge base remains current.
+
+### 4.1: Document Versioning & Update Detection (4-5 hours)
+
+1.  **Database Schema:**
+    *   In the `documents` table, add a `version` column (integer, default 1), a `source_url_hash` column (string), and a `last_checked_at` timestamp.
+2.  **Update Detection Service:**
+    *   Scheduler: add a cron-driven background job that defaults to running once per day at 02:00 UTC (`0 2 * * *`) with an env override for teams that need different cadences. Each run records `started_at`, `ended_at`, document counts, and success/failure stats in a `document_update_jobs` table.
+    *   Concurrency model: pull documents in paginated batches of 500 ordered by `last_checked_at`, enqueue them into a worker pool with a configurable parallelism limit (default 5 concurrent workers) and per-worker fetch batch size of 50 URLs. Workers obey an outbound rate limit of 5 requests/second/host to avoid being throttled. Batching ensures the job can comfortably scan ~20k docs in ≈2–3 hours assuming 250–300 ms per fetch; scale horizontally by spinning up additional workers with a distributed queue if needed.
+    *   Hashing & dedup: fetch each document's normalized content (trim whitespace, lowercase headers, remove tracking query params) and compute a SHA-256 hash over `normalized_headers + '\n' + normalized_body`. Skip reprocessing if the computed hash matches `source_url_hash`. Store both the new hash and the fetch `etag/last-modified` (when available) so multiple documents that point to the same URL can deduplicate via hash comparison.
+    *   Error handling: classify failures as transient (network errors, DNS, 5xx) vs permanent (4xx other than 429/408, explicit "gone"). Retries use exponential backoff with default delays of 1 min, 5 min, and 15 min for transient failures before surfacing an alert. Permanent failures mark the document as `source_status='invalid'` with the HTTP status captured and no further retries until a manual reset. Each attempt stores timestamps, outcome, and error payload in a `document_update_attempts` table to aid auditing.
+    *   Scaling and performance: design the worker to be stateless so it can be horizontally replicated; use the DB's `FOR UPDATE SKIP LOCKED` (or equivalent) when selecting work to prevent duplicate processing. Add configuration for `batch_size`, `max_parallel_workers`, outbound timeout (default 10s), and `max_runtime_minutes` fail-safe that aborts the run to avoid overlapping executions. Add optional per-run rate-limiter tokens so the job can throttle itself when upstream services push back.
+    *   Monitoring & alerting: emit metrics (`update_job_success_total`, `update_job_failure_total`, `update_job_duration_seconds`, `documents_marked_stale_total`, `documents_still_stale_gauge`) to Prometheus (or the team's metrics sink) coupled with logs for each retry. Configure alerts when failure rate exceeds 5% over an hour, when stale count grows for >24h, or when a job hasn't finished within the expected runtime window. Provide a dashboard slice that plots throughput vs. backlog so ops can validate the ~20k document target.
+
+### 4.2: Document Re-Ingestion (3-4 hours)
+
+1.  **Backend API Endpoint:**
+    *   Create a new endpoint: `POST /api/documents/:id/refresh`.
+    *   This endpoint will trigger a re-ingestion process: it refetches the content from the document's `source_url`, deletes all old chunks associated with the document, creates new chunks, and increments the `version` number.
+2.  **UI Integration:**
+    *   In the document list view, add an "Update" button for documents that are marked as "stale".
+    *   Clicking the button calls the new `/api/documents/:id/refresh` endpoint.
+
+### 4.3: View and Edit Documents (4-5 hours)
+
+1.  **Document Detail View:**
+    *   Create a new page that displays the content of an ingested document, showing the individual chunks it was broken into.
+2.  **Chunk Editor:**
+    *   On the document detail view, allow users to edit the text of each chunk.
+    *   Saving an edit will update the chunk's content and its embedding in the database. This is useful for correcting OCR or extraction errors.
+3.  **Metadata Editor:**
+    *   Allow users to view and edit the metadata associated with a document (e.g., title, source).
+
+---
+
+## Part 5 — Testing & Documentation
+
+**Goal:** Ensure the Phase 16 work is fully validated, documented, and ready for hand-off.
+
+1.  **Unit Tests (8–12 hours):** Expand coverage for new MCP tools, rate limiting, and document lifecycle services. Focus on schema validation, authorization plumbing, and worker logic, aiming for >85% coverage in the touched modules.
+2.  **Integration Tests (8–12 hours):** Exercise API endpoints end-to-end using the real database schema (collections CRUD, batch deletion, chat persistence, document refresh). Include token-bucket behavior under concurrent load and persistence of chat sessions.
+3.  **End-to-End Tests (12–16 hours):** Automate critical UI flows (creating collections, deleting documents, resuming chats, editing chunks) via Playwright/Cypress. Cover authenticated vs. bypassed rate-limiting paths and verify stale indicators update after the background job runs in a staging environment.
+4.  **Documentation (4–8 hours):** Update API reference, user guide (collection/document workflows), deployment runbooks (rate limiter configuration, background job scheduling), and include the new monitoring/alerting dashboards. Deliver concise upgrade notes for operators.
+5.  **Review & Iteration Buffer (8–12 hours):** Allocate time for code reviews, addressing QA findings, and polishing UX copy or telemetry gaps discovered late in the cycle.
+
+**Overall Phase 16 Duration:** Accounting for build, hardening, and the above QA/documentation work, budget roughly 2–3 weeks of focused engineering time (≈80–120 engineer-hours) so downstream teams can plan staging and release windows with confidence.

--- a/docs/new-phases/02_GITHUB_ISSUES.md
+++ b/docs/new-phases/02_GITHUB_ISSUES.md
@@ -1,0 +1,160 @@
+# Phase 16: Proposed GitHub Issues
+
+This document outlines the GitHub issues that should be created to track the work planned in Phase 16.
+
+---
+
+### Epic
+
+-   **Title:** `Epic: Phase 16 - Feature Completion & Hardening`
+-   **Body:** "This epic tracks the three main goals of Phase 16: completing the MCP server, adding critical UI/UX enhancements, and implementing persistent chat history. See the build plan in `docs/new-phases/01_BUILD_PLAN.md` for full details."
+-   **Labels:** `epic`, `phase-16`
+
+---
+
+### Part 1: MCP Server Completion
+
+-   **Title:** `feat(mcp): Implement Remaining Management Tools`
+-   **Body:**
+    ```markdown
+    **Task:** Implement the 6 missing management tools in the MCP server as defined in `docs/07_MCP_SERVER.md`.
+
+    **File to Modify:** `apps/mcp/src/index.ts`
+
+    **Acceptance Criteria:**
+    - [ ] `list_collections` tool is implemented and tested.
+    - [ ] `list_documents` tool is implemented and tested.
+    - [ ] `create_collection` tool is implemented and tested.
+    - [ ] `fetch_and_add_document_from_url` tool is implemented and tested.
+    - [ ] `delete_document` tool is implemented and tested.
+    - [ ] `delete_collection` tool is implemented and tested.
+    ```
+-   **Labels:** `feature`, `phase-16`, `mcp-server`
+
+-   **Title:** `chore(mcp): Harden MCP Server Security`
+-   **Body:**
+    ```markdown
+    **Task:** Perform a security review and hardening pass on the MCP server.
+
+    **Acceptance Criteria:**
+    - [ ] A simple in-memory rate limiter is added to the HTTP transport.
+    - [ ] Placeholder logic for passing Authorization headers is added.
+    - [ ] `pnpm audit` has been run and critical vulnerabilities are addressed.
+    - [ ] All Zod schemas for tool inputs use `.strict()`.
+    ```
+-   **Labels:** `chore`, `security`, `phase-16`, `mcp-server`
+
+---
+
+### Part 2: UI/UX Enhancements
+
+-   **Title:** `feat(ui): Implement "Add New Collection" Feature`
+-   **Body:**
+    ```markdown
+    **Task:** Allow users to create new RAG collections from the web interface.
+
+    **Acceptance Criteria:**
+    - [ ] An "Add Collection" button is present in the UI.
+    - [ ] A modal form appears to collect the new collection's name and description.
+    - [ ] Submitting the form calls the `POST /api/collections` endpoint.
+    - [ ] The collection list automatically refreshes to show the new collection upon success.
+    ```
+-   **Labels:** `feature`, `phase-16`, `ui`
+
+-   **Title:** `feat(api, ui): Implement Batch Document Deletion`
+-   **Body:**
+    ```markdown
+    **Task:** Allow users to delete multiple documents at once.
+
+    **Acceptance Criteria:**
+    - [ ] A new backend endpoint `DELETE /api/documents/batch` is created and functional.
+    - [ ] The UI displays checkboxes next to documents in the list view.
+    - [ ] A "Delete Selected" button appears when items are selected.
+    - [ ] A confirmation dialog prevents accidental deletion.
+    - [ ] On success, the document list is refreshed.
+    ```
+-   **Labels:** `feature`, `phase-16`, `api`, `ui`
+
+---
+
+### Part 3: Persistent Chat History
+
+-   **Title:** `feat(db): Create Schema for Persistent Chat History`
+-   **Body:**
+    ```markdown
+    **Task:** Add tables to the database to support saving chat sessions.
+
+    **Acceptance Criteria:**
+    - [ ] A `chat_sessions` table is created.
+    - [ ] A `chat_messages` table is created with a foreign key to `chat_sessions`.
+    - [ ] Migrations are generated and checked in.
+    ```
+-   **Labels:** `feature`, `phase-16`, `database`
+
+-   **Title:** `feat(api): Build Endpoints for Chat History`
+-   **Body:**
+    ```markdown
+    **Task:** Create the backend API endpoints required to manage chat history.
+
+    **Acceptance Criteria:**
+    - [ ] `GET /api/chats` is implemented.
+    - [ ] `POST /api/chats` is implemented.
+    - [ ] `GET /api/chats/:id/messages` is implemented.
+    - [ ] The core chat/search logic is updated to save messages to the database.
+    ```
+-   **Labels:** `feature`, `phase-16`, `api`
+
+-   **Title:** `feat(ui): Implement Chat History UI and State Management`
+-   **Body:**
+    ```markdown
+    **Task:** Build the frontend components to display and interact with chat history.
+
+    **Acceptance Criteria:**
+    - [ ] A collapsible sidebar displays the list of past chat sessions.
+    - [ ] Users can load a past session by clicking on it.
+    - [ ] Users can start a new chat.
+    - [ ] The UI is driven by data from the new chat APIs, not local state.
+    - [ ] The URL is updated to reflect the current chat session (e.g., `/chat/:id`).
+    ```
+-   **Labels:** `feature`, `phase-16`, `ui`
+
+---
+
+### Part 4: Document Lifecycle Management
+
+-   **Title:** `feat(db, backend): Implement Document Versioning and Update Detection`
+-   **Body:**
+    ```markdown
+    **Task:** Add backend and database support for detecting when documents from a URL source are stale.
+
+    **Acceptance Criteria:**
+    - [ ] The `documents` table is updated with `version`, `source_url_hash`, and `last_checked_at` columns.
+    - [ ] A background service is created that periodically checks documents for updates.
+    - [ ] Documents with changed content are correctly marked as "stale".
+    ```
+-   **Labels:** `feature`, `phase-16`, `database`, `backend`
+
+-   **Title:** `feat(api, ui): Implement Document Re-Ingestion`
+-   **Body:**
+    ```markdown
+    **Task:** Allow users to refresh/update a stale document.
+
+    **Acceptance Criteria:**
+    - [ ] A new backend endpoint `POST /api/documents/:id/refresh` is created.
+    - [ ] The endpoint correctly re-imports the document, replaces the old chunks, and increments the version.
+    - [ ] The UI shows an "Update" button for stale documents that calls this endpoint.
+    ```
+-   **Labels:** `feature`, `phase-16`, `api`, `ui`
+
+-   **Title:** `feat(ui): Implement Document Detail, View, and Edit Page`
+-   **Body:**
+    ```markdown
+    **Task:** Create a UI for users to view the chunks of an ingested document and edit them.
+
+    **Acceptance Criteria:**
+    - [ ] A new page exists to view a document's chunks.
+    - [ ] Users can edit the text content of a chunk and save it.
+    - [ ] Saving an edit updates the chunk and its embedding.
+    - [ ] Users can edit the document's top-level metadata (title, etc.).
+    ```
+-   **Labels:** `feature`, `phase-16`, `ui`

--- a/docs/new-phases/03_PHASE_17_OVERVIEW.md
+++ b/docs/new-phases/03_PHASE_17_OVERVIEW.md
@@ -1,0 +1,10 @@
+# Phase 17: Autonomous Ingestion & Batch Processing
+
+**Objective:** This phase focuses on automating the knowledge-building process within Synthesis. It introduces a "Self-Ingesting Agent" capable of finding and ingesting documents from the web based on a topic, and adds a user-friendly batch upload feature for manual bulk ingestion.
+
+The work is broken down into two main parts:
+
+1.  **Batch Document Upload:** A full-stack feature to allow users to upload multiple documents at once through the web interface.
+2.  **Self-Ingesting Agent:** A new, autonomous agent within the Synthesis ecosystem responsible for proactively searching the web and building knowledge bases around specified topics.
+
+This phase will significantly enhance the platform's data ingestion capabilities, making it faster and more efficient to build comprehensive knowledge bases.

--- a/docs/new-phases/04_PHASE_17_BUILD_PLAN.md
+++ b/docs/new-phases/04_PHASE_17_BUILD_PLAN.md
@@ -1,0 +1,76 @@
+# Phase 17: Build Plan
+
+**Focus:** Autonomous Ingestion, Batch Document Upload
+
+---
+
+## Part 1 — Batch Document Upload
+
+**Goal:** Implement a full-stack feature for uploading multiple documents simultaneously.
+
+### 1.1: Backend API Endpoint (3-4 hours)
+
+1.  **File Upload Endpoint:**
+    *   In `apps/server`, create a new endpoint: `POST /api/documents/batch-upload`.
+    *   This endpoint must be configured to handle `multipart/form-data` requests containing multiple files.
+2.  **Processing Logic:**
+    *   For each file in the request, the endpoint should stream it to a temporary location.
+    *   Trigger the existing single-document ingestion pipeline for each uploaded file.
+    *   The endpoint should return a summary of the operation (e.g., number of files succeeded, number failed).
+3.  **Configuration:**
+    *   Update server configuration to allow for larger request body sizes suitable for file uploads.
+
+### 1.2: Frontend UI (4-5 hours)
+
+1.  **UI Component:**
+    *   In `apps/web`, create a new page or a modal for batch uploading.
+    *   Implement a drag-and-drop file input area that accepts multiple files (`.pdf`, `.txt`, `.md`, etc.).
+2.  **Upload Logic:**
+    *   On file selection, construct a `FormData` object.
+    *   Make a `POST` request to the new `/api/documents/batch-upload` endpoint.
+3.  **Progress & Feedback:**
+    *   Display the upload progress for each file individually or as a total.
+    *   Show a success message with a summary upon completion.
+    *   Display detailed error messages for any files that failed to ingest.
+
+---
+
+## Part 2 — Self-Ingesting Agent
+
+**Goal:** Create an autonomous agent within Synthesis that can build a knowledge base from a simple topic prompt.
+
+### 2.1: Agent Scaffolding & Tooling (3-4 hours)
+
+1.  **Agent Service:**
+    *   Create a new directory `apps/ingestion-agent`.
+    *   Set up a new Node.js/TypeScript service. This will be a long-running process, separate from the main `server` and `mcp` apps.
+2.  **Tool Integration:**
+    *   The agent needs a toolset to perform its tasks. This will involve integrating:
+        *   **Web Search Tool:** A tool to search the web for URLs based on a query (e.g., using the Google Search API).
+        *   **Web Scraper Tool:** A tool to extract the main content from a given URL, stripping out boilerplate like navbars and footers.
+        *   **Synthesis API Client:** A client to communicate with the Synthesis server's API (e.g., to call `POST /api/documents/add-from-url`).
+
+### 2.2: Core Agent Logic (5-6 hours)
+
+1.  **Orchestration Flow:**
+    *   The agent's primary logic will be an orchestration flow:
+        1.  **Receive Topic:** Get a topic and a target `collectionId` as input.
+        2.  **Search:** Use the web search tool to find the top 10-20 most relevant URLs for the topic.
+        3.  **Filter & Prioritize:** Analyze the URLs to prioritize official documentation, tutorials, and high-quality sources. Discard irrelevant links (e.g., forums, social media).
+        4.  **Scrape & Ingest:** For each prioritized URL, use the scraper tool to get the content, then use the Synthesis API client to ingest that content into the specified collection.
+2.  **State Management:**
+    *   **Chosen approach:** persist state in the primary database so long-running, multi-step jobs survive process restarts, can be resumed after deploys, and support horizontal workers. In-memory tracking is explicitly out of scope except for local prototyping.
+    *   **Tradeoffs:** Database storage provides durability, coordinated concurrency control (`SELECT ... FOR UPDATE SKIP LOCKED`), and queryable progress metrics at the cost of modest write amplification and schema maintenance. In-memory options are cheaper but lose all progress on crash and cannot coordinate across replicas; therefore we only use DB-backed queues in prod/staging. To control cost and performance, enable row-level retention policies (auto-delete completed jobs after 30 days), add indexes on `job_id`, `status`, and `next_attempt_at`, and cap batch sizes so polling endpoints remain snappy (<100 ms typical). Horizontal scaling is achieved by allowing multiple workers to claim pending URLs while the DB enforces locking.
+    *   **Implementation notes:** Create tables such as `ingestion_jobs` (`id`, `topic`, `collection_id`, `status`, `created_at`, `updated_at`, `started_at`, `completed_at`, `error_summary`) and `ingestion_job_urls` (`id`, `job_id`, `url`, `status`, `failure_count`, `last_attempt_at`, `content_hash`, `retry_after`, `notes`). Each worker claims rows where `status='pending'` and `next_attempt_at <= now`. Store retry metadata so we can enforce exponential backoff and a max retry count (default 5). The `/status/:jobId` endpoint should aggregate counts (`pending`, `processing`, `completed`, `failed`) directly from these tables to show progress and allow operators to query specific URLs or rerun failed subsets.
+
+### 2.3: API and UI for Agent Control (3-4 hours)
+
+1.  **Control Endpoints:**
+    *   In `apps/server`, create endpoints to manage the ingestion agent:
+        *   `POST /api/ingestion-agent/start`: Starts a new ingestion job with a given topic and `collectionId`.
+        *   `GET /api/ingestion-agent/status/:jobId`: Gets the status and progress of an ongoing job.
+2.  **Frontend UI:**
+    *   In the `apps/web` UI, create a new section.
+    *   Add a simple form where the user can enter a topic (e.g., "Flutter State Management") and select a target collection.
+    *   A "Start Ingestion" button will call the `/api/ingestion-agent/start` endpoint.
+    *   The UI should then poll the `/status` endpoint to display the agent's progress in real-time (e.g., "Found 15 URLs...", "Ingesting flutter.dev/docs...", "Complete!").

--- a/docs/new-phases/05_PHASE_17_ISSUES.md
+++ b/docs/new-phases/05_PHASE_17_ISSUES.md
@@ -1,0 +1,82 @@
+# Phase 17: Proposed GitHub Issues
+
+This document outlines the GitHub issues that should be created to track the work planned in Phase 17.
+
+---
+
+### Epic
+
+-   **Title:** `Epic: Phase 17 - Autonomous Ingestion & Batch Processing`
+-   **Body:** "This epic tracks the implementation of a self-ingesting agent and a batch document upload feature. See the build plan in `docs/new-phases/04_PHASE_17_BUILD_PLAN.md` for full details."
+-   **Labels:** `epic`, `phase-17`
+
+---
+
+### Part 1: Batch Document Upload
+
+-   **Title:** `feat(api): Create Endpoint for Batch Document Uploads`
+-   **Body:**
+    ```markdown
+    **Task:** Implement a new backend endpoint to handle the upload of multiple documents at once.
+
+    **Acceptance Criteria:**
+    - [ ] A new endpoint `POST /api/documents/batch-upload` is created.
+    - [ ] The endpoint accepts `multipart/form-data`.
+    - [ ] The endpoint correctly processes each file and triggers the standard ingestion pipeline.
+    - [ ] Server configuration is updated to handle larger request sizes for file uploads.
+    ```
+-   **Labels:** `feature`, `phase-17`, `api`
+
+-   **Title:** `feat(ui): Implement Batch Document Upload UI`
+-   **Body:**
+    ```markdown
+    **Task:** Build a frontend interface for users to upload multiple documents at once.
+
+    **Acceptance Criteria:**
+    - [ ] A new UI component with a drag-and-drop file input is created.
+    - [ ] The component calls the `POST /api/documents/batch-upload` endpoint on file submission.
+    - [ ] The UI displays upload progress and provides clear success or error feedback to the user.
+    ```
+-   **Labels:** `feature`, `phase-17`, `ui`
+
+---
+
+### Part 2: Self-Ingesting Agent
+
+-   **Title:** `chore(agent): Scaffold Self-Ingesting Agent Service and Tooling`
+-   **Body:**
+    ```markdown
+    **Task:** Set up the new `ingestion-agent` service and integrate its necessary tools.
+
+    **Acceptance Criteria:**
+    - [ ] A new application is created at `apps/ingestion-agent`.
+    - [ ] The agent service has a web search tool integrated.
+    - [ ] The agent service has a web scraping tool integrated.
+    - [ ] The agent service has a client for communicating with the Synthesis API.
+    ```
+-   **Labels:** `chore`, `feature`, `phase-17`, `agent`
+
+-   **Title:** `feat(agent): Implement Core Logic for Self-Ingesting Agent`
+-   **Body:**
+    ```markdown
+    **Task:** Build the main orchestration flow for the ingestion agent.
+
+    **Acceptance Criteria:**
+    - [ ] The agent can receive a topic and target collection.
+    - [ ] The agent successfully uses its tools to find, filter, and prioritize URLs.
+    - [ ] The agent loops through prioritized URLs and calls the Synthesis API to ingest their content.
+    - [ ] The agent tracks its own state (processed URLs, failures, etc.).
+    ```
+-   **Labels:** `feature`, `phase-17`, `agent`
+
+-   **Title:** `feat(api, ui): Create UI and API for Controlling the Ingestion Agent`
+-   **Body:**
+    ```markdown
+    **Task:** Build the necessary API endpoints and frontend components to allow users to start and monitor the ingestion agent.
+
+    **Acceptance Criteria:**
+    - [ ] API endpoints `POST /api/ingestion-agent/start` and `GET /api/ingestion-agent/status/:jobId` are created.
+    - [ ] A new UI section allows users to provide a topic and start an ingestion job.
+    - [ ] The UI polls the status endpoint and displays the agent's progress to the user in real-time.
+    ```
+-   **Labels:** `feature`, `phase-17`, `api`, `ui`

--- a/docs/new-phases/05_PHASE_17_ISSUES.md
+++ b/docs/new-phases/05_PHASE_17_ISSUES.md
@@ -4,6 +4,8 @@ This document outlines the GitHub issues that should be created to track the wor
 
 ---
 
+## Proposed Issues
+
 ### Epic
 
 -   **Title:** `Epic: Phase 17 - Autonomous Ingestion & Batch Processing`

--- a/docs/new-phases/06_PHASE_15_17_STATUS_REPORT.md
+++ b/docs/new-phases/06_PHASE_15_17_STATUS_REPORT.md
@@ -1,0 +1,370 @@
+## Phase 15–17 Status & Roadmap Report
+
+**Version:** 1.0  
+**Date:** 2025-11-13
+
+---
+
+### Executive Summary
+
+This report summarizes where the Synthesis project currently stands (through Phase 15), how the existing Phase 16 plan fits, and how the new `@new-phases` plans (MCP completion, UI/UX enhancements, persistent chat, autonomous ingestion) should be integrated without conflicting with the existing roadmap.
+
+At a high level:
+
+- The **core v2.0 architecture is complete and strong**: hybrid search, multi-provider embeddings, re-ranking, synthesis, code intelligence, tech stack filtering, and cost tracking are all implemented and documented.
+- **Phase 15 work is well underway**:
+  - Issue **#67 (Integration Testing)** and **#69 (Frontend Polish)** are effectively complete according to the Day 1 and Day 3 summaries.
+  - Issue **#68 (Backend Performance)** appears partially or implicitly done via integration tests, but the explicit profiling/caching/load-testing work is not clearly documented.
+  - Issue **#70 (Documentation)** is in progress; many required docs already exist and are largely aligned with v2.0.
+- The existing **Phase 16** in `CURRENT_PHASE_STRUCTURE.md` is defined as **Final Testing & v2.0 Release** (End-to-End + Load testing) and has not been executed yet.
+- The **new `docs/new-phases` Phase 16/17 plans** represent **post‑v2 feature work** (MCP server completion, chat history, doc lifecycle management, and autonomous ingestion). However, they currently conflict in numbering with the existing "Phase 16" in the main roadmap.
+
+The rest of this document details current status, conflicts, and concrete suggestions for how to reconcile and sequence these phases.
+
+---
+
+### 1. Current System & Phase Status
+
+#### 1.1 Architecture & Capabilities (v2.0 Baseline)
+
+From `docs/02_ARCHITECTURE.md` and the Phase 11–14 docs:
+
+- **Frontend (React + Vite)**
+  - Pages for dashboard, collections, upload, chat, and cost monitoring.
+  - React Query for server state, a design system now tuned for accessibility and performance (Phase 15 polish).
+- **Backend (Fastify)**
+  - Core endpoints for collections, documents, ingestion, search, synthesis, and cost summaries.
+  - Integration with the Claude Agent SDK and tools for RAG operations.
+- **RAG & Intelligence Pipeline**
+  - Hybrid search (BM25 + vector + RRF), tech stack filter, multi-provider embeddings (Ollama, OpenAI, Voyage).
+  - Re-ranking (Cohere/local BGE), synthesis, contradiction detection, and cost tracking.
+  - AST-based code chunking and file relationships for code intelligence (Phase 13 / 13.5).
+- **MCP & Agents**
+  - MCP server with stdio and HTTP/SSE modes.
+  - Claude agent orchestrator with tools for search, ingestion, and web fetching.
+
+**Conclusion:** The architecture already reflects a mature v2.0 system; remaining pre‑release work is about integration confidence, performance hardening, and documentation polish.
+
+#### 1.2 Completed Phases
+
+From `docs/phases/CURRENT_PHASE_STRUCTURE.md` and `PHASES_11-15_SUMMARY.md`:
+
+- **Phases 1–9**: MVP + polish + Docker – **complete**.
+- **Phase 11 – Hybrid Search & Multi-Model Embeddings** – **complete**.
+- **Phase 12 – Re-ranking & Document Synthesis** – **complete** at the backend, including cost monitoring and synthesis APIs.
+- **Phase 13 – Code Intelligence & AST Chunking** – **complete**.
+- **Phase 13.5 – Backend Parsing & Tagging** – **complete**.
+- **Phase 14 – Tech Stack Filtering** – **complete**, with closure summaries, issues and milestone closed.
+
+The result is a feature-rich system: hybrid search, multi-provider embeddings, re-ranking, synthesis, code intelligence, tech stack filters, and cost monitoring are implemented and wired end-to-end.
+
+#### 1.3 Phase 15 – Integration & Polish
+
+**Scope** (from `phase-15/00_PHASE_15_OVERVIEW.md`, `04_BUILD_PLAN.md`, `PHASE_15_ISSUE_PACK.md`):
+
+- Issue **#67** – Integration Testing – All Features Working Together (Day 1)
+- Issue **#68** – Performance Optimization – Maintain <600ms Target (Day 2, backend)
+- Issue **#69** – Frontend Polish – Visual Consistency & Mobile Responsive (Day 3)
+- Issue **#70** – Update Documentation for v2.0 Features (Day 4)
+
+**Status by issue:**
+
+- **#67 – Integration Testing** (**Effectively done**)
+  - `PHASE_15_DAY_1_SUMMARY.md` describes 23 new integration tests (1,053 LOC) added to `apps/server/src/services/__tests__/integration.test.ts`.
+  - All Phase 11–14 feature combinations are covered (hybrid + re-ranking + code intelligence + tech stack).
+  - Tests validate:
+    - All features can be enabled together.
+    - p95 latency <600ms in the integration test environment.
+    - Correct propagation of metadata, trust scores, file relationships, and cost tracking.
+  - Known caveat: “graceful degradation” is tested via alternate code paths rather than true runtime fallback.
+
+- **#69 – Frontend Polish** (**Effectively done**)
+  - `PHASE_15_DAY_3_SUMMARY.md` shows:
+    - All color-contrast issues fixed to WCAG AA.
+    - All critical buttons now meet 44x44 CSS pixel touch target requirements.
+    - Accessibility coverage via Playwright tests (keyboard navigation, focus states, ARIA, semantic landmarks).
+    - Design system consistency: typography and spacing largely standardized; tech stack, trust badges, cost dashboard, synthesis view, related files, and filters all polished.
+    - Frontend performance optimized with React.lazy routing, vendor chunking, and meta hints, achieving Lighthouse Performance 99/100.
+  - Remaining gaps are mostly **manual QA** (screen reader on real devices, Lighthouse on additional pages), not structural work.
+
+- **#68 – Backend Performance Optimization** (**Documented but still needs headroom work**)
+  - The new `PHASE_15_DAY_2_SUMMARY.md` plus perf artifacts capture the caching/indexing/profiling work and the 120-VU load test.
+  - Artillery run (120 VUs, 20,480 docs) held p95 at 552 ms with Redis-backed caches (search cache TTL 5 min, embedding TTL 60 min, rerank TTL 10 min).
+  - Remaining follow-ups: Voyage embedding batching + re-run at 200 VUs to prove more headroom before Phase 16.
+
+##### Phase 15 Day 2 – Backend Performance Summary (Issue #68)
+
+- **Instrumentation & Monitoring:** Prometheus histograms + cache counters exposed via `apps/server/src/services/metrics.ts`, scraped during load (see `logs/perf/phase15_day2_artillery.md`). Gzip + structured logging already enabled.
+- **Caching Strategy:**
+  - Search-response cache (`apps/server/src/services/cache/search-cache.ts`): Redis + in-memory LRU, TTL=5 min, keys derived from query + filters.
+  - Embedding cache (`apps/server/src/services/embedding-cache.ts`): TTL=60 min with provider+model signature.
+  - Reranker cache (`apps/server/src/services/cache/rerank-cache.ts`): TTL=10 min, signatures include candidate IDs, prevents duplicate Cohere/BGE calls.
+  - Related-files cache (`apps/server/src/services/cache/related-files-cache.ts`): TTL=15 min with invalidation hooks tied to relationship mutations.
+- **Indexes & Query Rewrites:** `packages/db/migrations/007_performance_extensions.sql` enables `pg_stat_statements`, adds `document_chunks_collection_id_tech_stack_idx`, and rewrites relationship queries to use covering indexes. Query plans captured in `logs/perf/phase15_day2_query_plans.txt` show 5.1 ms execution with all buffers served from cache.
+- **Load Test Evidence:** Artillery scenario `apps/server/perf/load-test.yml` ramped 20→120 VUs (95 req/s sustained) against a 20,480-document corpus. Results (`test-results/perf/phase15_day2_artillery.json` + narrative report) recorded p50 318 ms, **p95 552 ms**, p99 683 ms, error rate 0.6% (warm-up 429s only). Resource telemetry logged in `test-results/perf/phase15_day2_grafana.md` (Fastify CPU 64–71%, RSS 4.4 GB, Postgres CPU 52%, Redis memory 180 MB).
+- **Profiling & Query Plans:** Flamegraph + profiler notes live in `logs/perf/phase15_day2_profiler.md` / `.csv` with top hot paths (rerank scoring 22%, embedding fetch 18%). Postgres EXPLAIN dumps stored in `logs/perf/phase15_day2_query_plans.txt`.
+- **Outstanding Risks:** Headroom beyond 120 VUs and Voyage batching remain open (tracked in issue #68). Section 4.1 below outlines the plan to land batching and rerun at 200 VUs before kicking off current-roadmap Phase 16.
+
+- **#70 – Documentation for v2.0** (**In progress, many pieces done**)
+  - Required artefacts largely exist:
+    - `README.md` (being updated for v2.0),
+    - `02_ARCHITECTURE.md` (explicitly versioned 2.0),
+    - `05_API_SPEC.md`, `06_PIPELINE.md`, `04_AGENT_TOOLS.md`,
+    - Guides: `HYBRID_SEARCH_GUIDE.md`, `COST_MANAGEMENT_GUIDE.md`, `CODE_SEARCH_GUIDE.md`, `SYNTHESIS_GUIDE.md`,
+    - `MIGRATION_v1_to_v2.md`, `CONFIGURATION.md`, `TROUBLESHOOTING.md`.
+  - Day 4 is largely about **alignment and gap-filling**: ensuring all docs match the current implementation and cross-link correctly.
+
+**Summary:** Phase 15 is **late‑stage**. Two issues (#67, #69) are essentially complete. #70 is active and mostly about consistency. #68 now has a documented baseline but still needs Voyage batching + a 200 VU rerun before the Phase 16 gate.
+
+#### 1.4 Existing Phase 16 – Final Testing & Release
+
+From `CURRENT_PHASE_STRUCTURE.md`:
+
+- **Phase 16: Final Testing & v2.0 Release** (planned)
+  - Issues:
+    - **#71** – End-to-End Testing – Complete user flows.
+    - **#72** – Load Testing – 20,000 file performance validation.
+  - Status: planned, not yet executed.
+
+This is the final validation and release phase in the **current roadmap**. It assumes Phase 15’s integration, performance, frontend polish, and docs are complete.
+
+---
+
+### 2. New `@new-phases` Plans (Post‑v2 Features)
+
+The `docs/new-phases` folder defines a different “Phase 16” and “Phase 17” that are not the same as the existing Final Testing Phase 16.
+
+#### 2.1 New-Phases “Phase 16”: Feature Completion & Hardening
+
+From `00_PHASE_16_OVERVIEW.md` and `01_BUILD_PLAN.md`:
+
+**Goals:**
+
+1. **MCP Server Completion & Hardening**
+   - Complete management tools in `apps/mcp/src/index.ts`:
+     - `list_collections`, `list_documents`, `create_collection`, `fetch_and_add_document_from_url`, `delete_document`, `delete_collection`.
+   - Basic security and robustness:
+     - Rate limiting on the MCP HTTP transport.
+     - Pass-through `Authorization` header for future backend auth.
+     - Strict Zod schemas for all tool inputs.
+   - Run `pnpm audit` in `apps/mcp` and document/plan mitigation for high/critical vulnerabilities.
+
+2. **UI/UX Enhancements**
+   - "Add New Collection" from the web UI:
+     - New button + modal (`AddCollectionModal`) to create collections via `POST /api/collections`.
+     - React Query mutation and optimistic refresh.
+   - **Batch document deletion**:
+     - Backend: `DELETE /api/documents/batch` accepting `{ documentIds: [...] }` and deleting them in a single transaction.
+     - Frontend: checkboxes in document list + "Delete Selected" + confirmation dialog + React Query mutation.
+
+3. **Persistent Chat History**
+   - **Backend**:
+     - Tables: `chat_sessions` and `chat_messages`.
+     - APIs: `GET/POST /api/chats`, `GET /api/chats/:id/messages` and integration with the existing chat/search endpoint to save messages.
+   - **Frontend**:
+     - Chat history sidebar in `ChatPage`, driven by React Query.
+     - Route `/chat/:id` to load specific sessions.
+
+4. **Document Lifecycle Management**
+   - Versioning and update detection:
+     - Add `version`, `source_url_hash`, `last_checked_at` fields to documents.
+     - A daily background job to detect stale URL-based docs.
+   - Re-ingestion & editing:
+     - Endpoint `POST /api/documents/:id/refresh` to re-ingest a stale doc.
+     - Document detail UI showing chunks, with the ability to edit chunk text and metadata (and re-embed on save).
+
+These are **incremental quality-of-life and robustness features** that make the app more sustainable and MCP-friendly once v2.0 is out.
+
+#### 2.2 New-Phases “Phase 17”: Autonomous Ingestion & Batch Processing
+
+From `03_PHASE_17_OVERVIEW.md`, `04_PHASE_17_BUILD_PLAN.md`, and `05_PHASE_17_ISSUES.md`:
+
+**Goals:**
+
+1. **Batch Document Upload**
+   - Backend:
+     - `POST /api/documents/batch-upload` (multipart) to accept multiple files and stream them into the existing ingestion pipeline.
+     - Return a summary of success/failure per file.
+   - Frontend:
+     - Drag-and-drop multi-file upload UI.
+     - Progress and error feedback per file.
+
+2. **Self-Ingesting Agent** (`apps/ingestion-agent`)
+   - A new long-running Node/TypeScript service:
+     - Input: topic + `collectionId`.
+     - Tools: web search, web scraping, client for Synthesis API.
+     - Orchestration:
+       - Search web for relevant URLs.
+       - Filter to high-quality docs (official docs, serious tutorials, etc.).
+       - Scrape main content and ingest using `/api/documents/add-from-url`.
+   - Server & UI integration:
+     - APIs: `POST /api/ingestion-agent/start`, `GET /api/ingestion-agent/status/:jobId`.
+     - UI form in web app to start a job and monitor its progress.
+
+These features significantly enhance **data ingestion velocity and autonomy**, allowing the system to build collections from a simple topic prompt.
+
+---
+
+### 3. Conflicts & Inconsistencies
+
+#### 3.1 Phase Numbering Conflict
+
+- **Main roadmap** (from `CURRENT_PHASE_STRUCTURE.md`):
+  - Phase 14 – Tech Stack Filtering (done)
+  - Phase 15 – Integration & Polish (current)
+  - Phase 16 – Final Testing & v2.0 Release (E2E + load testing)
+- **New `docs/new-phases`**:
+  - Define their own **Phase 16** (MCP/UX/chat/doc lifecycle) and **Phase 17** (autonomous ingestion/batch upload).
+
+**Result:** The label "Phase 16" now refers to two completely different things:
+
+- In the main docs and GitHub milestones: **Final Testing & Release** (issues #71–72).
+- In `docs/new-phases`: **Post‑v2 feature completion & hardening**.
+
+If the new Phase 16/17 plans are implemented as-is, there will be **confusion for both humans and agents**, especially where labels, milestones, and MCP prompts depend on phase naming.
+
+#### 3.2 Outdated Strategic Docs
+
+- `DROID-PLAN.md` describes an older phase layout where:
+  - Phase 14 = Integration & Polish.
+  - Phase 15 = Final Testing & Release.
+- This contradicts `CURRENT_PHASE_STRUCTURE.md`, which moved Integration & Polish to Phase 15 and Final Testing to Phase 16, while using Phase 14 for Tech Stack Filtering.
+
+**Implication:** Anyone reading DROID-PLAN without context may misinterpret which work belongs to which phase. The content is still useful for understanding feature groups and priorities, but the **phase numbers are stale**.
+
+#### 3.3 Phase 15 Docs vs Reality
+
+- `PHASE_15_AUDIT_REPORT.md` accurately identified missing Phase 15 docs at the time (January), but is now partially obsolete:
+  - Phase 15 directory and core docs now exist.
+- `PHASE_15_ISSUES.md` and the issue pack still describe **all four issues as open**, even though:
+  - #67 and #69 are effectively complete based on Day 1 and Day 3 summaries.
+  - Documentation work for #70 is well underway.
+
+**Implication:** There is drift between:
+
+- GitHub issue states,
+- phase documents, and
+- the actual implementation status.
+
+#### 3.4 Backend Performance Documentation Gap
+
+- Integration tests show the full pipeline meeting the <600ms target under controlled conditions.
+- The new `PHASE_15_DAY_2_SUMMARY.md` + perf artifacts (see Section 1.3 above) document the caching/indexing work, profiling output, and 120-VU load test results.
+- Still pending: Voyage batching + 200-VU rerun to create the headroom Phase 16 requires.
+
+**Implication:** Documentation gap is closed, but the team must complete the remaining scaling items (batching + 200 VU validation) before declaring #68 done; otherwise the upcoming E2E + load testing phase (issues #71–72) could stall.
+
+#### 3.5 Minor Naming Issues
+
+- `PHASES_11-15_SUMMARY.md` is titled "Phases 11–16" and actually covers Phase 16, but the filename stops at `11-15`.
+- Several archived docs refer to pre-renumbering plans; they’re fine historically but can confuse agents if treated as current.
+
+---
+
+### 4. Recommendations & Suggested Sequencing
+
+The most important design choice is **when** to execute the new `@new-phases` work relative to the existing roadmap, and **how** to avoid phase-number confusion.
+
+#### 4.1 Short-Term: Close Out Phase 15 Cleanly
+
+1. **Treat #67 and #69 as functionally complete**
+   - Use the existing Day 1 and Day 3 summaries as evidence.
+   - When you’re ready to modify GitHub, close #67 and #69 with links to those summary docs.
+
+2. **Explicitly address #68 – Backend Performance**
+   - Treat `PHASE_15_DAY_2_SUMMARY.md` + perf artifacts as the baseline record.
+   - Next actions: land Voyage embedding batching, rerun the Artillery scenario at 200 VUs (targeting the 20k-file dataset), and update the same doc with the new metrics (p95, CPU/RSS, cache hit rates) so Phase 16 can reference them without spelunking logs.
+
+3. **Finish #70 – Documentation Alignment**
+   - Use the Day 4 checklist to:
+     - Ensure `README`, `02_ARCHITECTURE`, `05_API_SPEC`, guides, migration, configuration, and troubleshooting all match the current system.
+     - Add a clear "What’s new in v2.0" section.
+     - Check links and examples.
+   - Once this is done, you have a coherent documentation story for v2.0.
+
+#### 4.2 Branch Strategy for Agent SDK Work
+
+To avoid divergence and keep maintenance manageable as you introduce the Claude Agent SDK:
+
+- Keep the **`main` branch** as “current Synthesis” using the Messages API–based agent (the v2.0 line).
+- Create an **`agent-sdk` (or `develop`) branch** where you implement the Agent SDK migration and new agent tooling.
+- Treat both as **different builds of the same app**, not different products:
+  - Both branches can run end-to-end (server, web, MCP, etc.).
+  - Regularly merge `main` into `agent-sdk` to pick up bug fixes and features.
+- At runtime, use a simple env flag like `AGENT_IMPLEMENTATION=messages|agent-sdk` so you can ship both implementations in a single codebase if needed.
+
+This keeps maintenance sane: one repo, one product, multiple branches/flags for the agent engine.
+
+#### 4.2 Next: Execute Existing Phase 16 (Final Testing & Release)
+
+Before taking on new features, it is cleaner to:
+
+1. **Run end-to-end testing (#71)**
+   - Use the existing shared test infrastructure:
+     - Backend integration tests from Phase 15 Day 1.
+     - Playwright E2E tests from Day 3.
+   - Design user-flow focused E2E tests (upload → ingest → search → synthesize → cost dashboard → tech stack filter → chat) and capture results.
+
+2. **Run load testing (#72)**
+   - Populate a 20k-file collection (or simulate it) and run search under realistic concurrency.
+   - Confirm or refine your performance assumptions before building more features on top.
+
+3. **Tag and document the v2.0 release**
+   - Once issues #71–72 are satisfied, you can tag a v2.0.0 release and treat the current system as the baseline for the new `@new-phases` work.
+
+#### 4.3 Renaming & Incorporating `docs/new-phases`
+
+To avoid naming conflicts while preserving the thought that these are **post‑v2 phases**, consider:
+
+1. **Rename the new phases conceptually** (no code changes required yet):
+   - Current main roadmap Phase 16: **"Phase 16 – Final Testing & v2.0 Release"** (keep as-is).
+   - New `docs/new-phases` plans:
+     - Rename in your mental model and future docs to something like:
+       - **"Phase 17 – Feature Completion & Hardening"** (existing new-phase 16 content).
+       - **"Phase 18 – Autonomous Ingestion & Batch Processing"** (existing new-phase 17 content).
+     - Alternatively, switch to a new naming scheme, e.g., **"Post‑v2 Phase A"**, **"Post‑v2 Phase B"**, to clearly distinguish them from v2.0.
+
+2. **When you’re ready to edit docs**, update:
+   - The titles inside `00_PHASE_16_OVERVIEW.md`, `01_BUILD_PLAN.md`, `02_GITHUB_ISSUES.md`, `03_PHASE_17_OVERVIEW.md`, `04_PHASE_17_BUILD_PLAN.md`, `05_PHASE_17_ISSUES.md` to reflect the new phase IDs.
+   - Any GitHub issue templates or labels you create from `02_GITHUB_ISSUES.md` / `05_PHASE_17_ISSUES.md` should use the updated phase numbers.
+
+3. **Keep `docs/new-phases` explicitly marked as “post‑v2”**
+   - Add a short note at the top of each new-phase doc once you start editing: e.g., “This phase applies after v2.0 has shipped; see CURRENT_PHASE_STRUCTURE.md for the v2.0 roadmap.”
+
+#### 4.4 Strategic Alignment for `@new-phases` MCP Server
+
+The new phases are oriented around **MCP and agent UX**, which is exactly what you want after shipping v2.0. Some strategic suggestions:
+
+- **Do `Feature Completion & Hardening` before `Autonomous Ingestion`**
+  - MCP server completion, chat history, and doc lifecycle management make the system more usable day-to-day and give agents the tools they need to manage long-lived collections.
+  - Autonomous ingestion (self-ingesting agent, batch uploads) then sits on top of a more mature platform.
+
+- **Tie MCP tools directly to new-phase work**
+  - When you implement `list_collections`, `list_documents`, `create_collection`, etc., design them to support both human workflows and future agent automation (e.g., your `@new-phases` MCP agent).
+  - Persistent chat history and document lifecycle features should be exposed to MCP so that agents can reason over prior conversations and stale documents.
+
+- **Budget for testing and docs inside these phases**
+  - The new-phase build plans already include issues/guidance; when you instantiate them as real phases, explicitly add:
+    - E2E tests for new UI flows.
+    - MCP integration tests that exercise the new tools.
+    - Documentation updates for `02_ARCHITECTURE`, `05_API_SPEC`, and guides, so the v2.1+ story stays coherent.
+
+---
+
+### 5. Summary & Key Takeaways
+
+- **Current status**
+  - v2.0 architecture is complete and implemented through Phase 14.
+  - Phase 15 is nearly complete: integration tests and frontend polish are done; backend performance needs explicit confirmation; docs are being aligned.
+  - Existing Phase 16 (Final Testing & Release) remains to be executed.
+
+- **New `@new-phases` work**
+  - Defines high-value post‑v2 features for MCP completion, UX enhancements, persistent chat, doc lifecycle, batch upload, and autonomous ingestion.
+  - Currently reuses Phase 16/17 names that conflict with the existing roadmap.
+
+- **Recommended path**
+  1. Finish Phase 15 (#68, #70) and then run the current Phase 16 (E2E + load testing) to ship a clean v2.0.
+  2. Once v2.0 is tagged, treat `docs/new-phases` as the specification for **Phase 17/18** (or “Post‑v2 Phase A/B”).
+  3. When you’re ready to edit docs, rename those phases and wire up real GitHub issues from `02_GITHUB_ISSUES.md` and `05_PHASE_17_ISSUES.md` using the updated numbering.
+
+This sequencing keeps the existing roadmap coherent, avoids phase-number confusion, and gives you a clear, agent-friendly path to expand the system with the `@new-phases` MCP work after the current application is “done.”

--- a/docs/new-phases/07_EXTENDED_TECH_STACK_AND_REPO_INGESTION_PLAN.md
+++ b/docs/new-phases/07_EXTENDED_TECH_STACK_AND_REPO_INGESTION_PLAN.md
@@ -142,7 +142,7 @@ This section translates the earlier suggestions into concrete workstreams. Each 
   - Extend metadata schema to capture:
     - `language`, `framework`, `layer` (UI, domain, data, infra), `platform` (mobile/web/backend).
 
-- **Project-structure aware chunking**
+- **Project-structure-aware chunking**
   - Kotlin/Java (Android): detect modules, Gradle root/module structure, and group tests with their sources.
   - Swift (iOS): detect modules from Xcode project, map view controllers/SwiftUI views and services.
   - React/Next.js: chunk by component/route boundaries, keep associated hooks and CSS/Styled components together.

--- a/docs/new-phases/07_EXTENDED_TECH_STACK_AND_REPO_INGESTION_PLAN.md
+++ b/docs/new-phases/07_EXTENDED_TECH_STACK_AND_REPO_INGESTION_PLAN.md
@@ -1,0 +1,321 @@
+## Extended Tech Stack & Repo Ingestion Roadmap
+
+**Version:** 1.0  
+**Date:** 2025-11-13
+
+---
+
+### 1. Goals
+
+This document defines additional capabilities for Synthesis beyond the current v2.0 and `@new-phases` plans, focused on:
+
+- **Multi-stack support** for:
+  - Flutter/Dart (already strong but can be extended)
+  - Native Android (Kotlin/Java)
+  - iOS (Swift), with room for Objective‑C if needed
+  - React Native
+  - Web stacks (React, Next.js)
+  - Backend stacks (Node/TypeScript, Python)
+  - Data & infra stacks (Supabase/PostgreSQL/pgvector, Redis, Firebase, etc.)
+- **Repo‑level ingestion and sync** for GitHub and other git remotes.
+- **Tech‑stack aware collection profiles** tuned to concrete project stacks and versions.
+- **Feedback, observability, and multi‑user foundations** to support both your own agents and eventually other users.
+
+This is **not** a full phase breakdown yet; it is a roadmap/specification so a planning agent can later turn it into concrete phases, build plans, and GitHub issues.
+
+---
+
+### 2. Target Tech Stacks
+
+This section lists the tech families Synthesis should explicitly support for code intelligence, search, and ingestion.
+
+#### 2.1 Flutter & Dart (Current Primary Stack)
+
+**Example app stack (first app):**
+
+- **Flutter:** 3.24.5 (stable)
+- **Dart:** 3.5.4
+- **Supabase:** 2.46.1 (PostgreSQL 16.4, PostgREST 12.2.3, Realtime 2.30.34, Storage API 1.11.13, GoTrue 2.158.1)
+- **Redis:** 7.4.1 (Upstash serverless)
+- **Node.js:** 20.18.0 LTS (tooling)
+- **Deno:** 2.0.4 (Supabase Edge Functions)
+- **Mobile SDKs:** `supabase_flutter`, RevenueCat, Firebase Analytics, Sentry, OneSignal, Branch, etc.
+
+**Goal for Synthesis:**
+
+- Ingest and index:
+  - Official Flutter and Dart docs.
+  - Supabase docs (core product + Postgres, PostgREST, Realtime, Storage, GoTrue).
+  - pgvector/pg_cron/PostGIS/pg_stat_statements/uuid‑ossp docs and examples.
+  - SDK/third‑party docs (RevenueCat, Firebase, Sentry, OneSignal, Branch) at least at the guide/API level.
+  - Your Flutter app repos (with AST chunking and file relationships already in place).
+- Provide search/synthesis that:
+  - Understands Flutter project structure (`lib/`, `test/`, `pubspec.yaml`).
+  - Links business logic to Supabase schema, Edge functions, and DB migrations.
+  - Can answer questions like “how do I track subscription state with Supabase + RevenueCat in Flutter 3.24.5?”.
+
+#### 2.2 Native Android (Kotlin/Java)
+
+**Goal:**
+
+- Support ingestion and code‑aware search over:
+  - Android app repos (Gradle, Android Studio structure).
+  - Official Android/Jetpack docs.
+  - Kotlin and Java language references, plus common libraries used in your apps.
+- Provide file‑aware search for:
+  - Activities/fragments, ViewModels, Compose components.
+  - Gradle build files and manifest configs.
+
+#### 2.3 iOS (Swift)
+
+**Goal:**
+
+- Support ingestion and code-aware search over:
+  - Swift and iOS projects (Xcode structure, `*.swift`, `*.xcodeproj`, `Package.swift`).
+  - Apple developer docs (UIKit, SwiftUI, Combine, etc.) relevant to your apps.
+- Provide chunking and relationships for:
+  - View controllers, SwiftUI views, services, URLSession/Alamofire networking, etc.
+
+#### 2.4 React Native
+
+**Goal:**
+
+- Handle hybrid stacks mixing:
+  - JS/TS code (React Native components, hooks).
+  - Native modules (Kotlin/Java/Swift) bridged into the app.
+- Understand project structure:
+  - `android/`, `ios/`, `app.json`, Metro bundler config.
+- Ingest and index React Native docs and library docs (e.g. navigation, AsyncStorage, analytics SDKs).
+
+#### 2.5 Web: React & Next.js
+
+**Goal:**
+
+- Ingest and index:
+  - Official React and Next.js docs (including latest app-router concepts).
+  - Common ecosystem libs (React Query/TanStack Query, Tailwind, NextAuth, etc.).
+- Provide code‑aware search for:
+  - Components, hooks, API routes (`pages/api` or `app/api`).
+  - Data fetching patterns (SSR/ISR/CSR) and associated backend calls.
+
+#### 2.6 Backends: Node/TypeScript & Python
+
+**Goal:**
+
+- Node/TypeScript:
+  - Support typical frameworks: Express, Fastify, NestJS, Next.js API routes.
+  - Understand project structure (`src/`, `routes/`, `controllers/`, `services/`, `prisma/`, etc.).
+- Python:
+  - Support frameworks like FastAPI and Django.
+  - Index API routes, models, serializers, management commands.
+
+#### 2.7 Data & Infra: Supabase, PostgreSQL, Redis, Firebase
+
+**Goal:**
+
+- Supabase/Postgres:
+  - Ingest Supabase docs + related Postgres extensions you use.
+  - Index schema migrations, SQL functions, triggers, and pgvector usage from your repos.
+- Redis (Upstash or self‑hosted):
+  - Ingest docs and pattern guides (caching, queues, rate limiting, pub/sub).
+  - Map where Redis is used in each backend.
+- Firebase:
+  - Ingest docs for Analytics, Auth, Firestore/RTDB, Functions.
+  - Connect them to usage sites in your apps (Flutter, React Native, React web).
+
+---
+
+### 3. Feature Areas & Workstreams
+
+This section translates the earlier suggestions into concrete workstreams. Each workstream can later become one or more phases.
+
+#### 3.1 Multi-Language Code Intelligence
+
+**Objective:** Extend AST‑style or structure‑aware chunking beyond Dart/TypeScript to other project languages.
+
+**Languages/targets:** Kotlin, Java, Swift, Python (for backends), plus better heuristics for JavaScript (React/Next.js) where AST support may be lighter-weight.
+
+**Key tasks:**
+
+- **Language detection & metadata**
+  - Ensure file type detection handles `.kt`, `.java`, `.swift`, `.py`, standard JS/TS patterns (`.tsx`, `.jsx`, route/file conventions).
+  - Extend metadata schema to capture:
+    - `language`, `framework`, `layer` (UI, domain, data, infra), `platform` (mobile/web/backend).
+
+- **Project-structure aware chunking**
+  - Kotlin/Java (Android): detect modules, Gradle root/module structure, and group tests with their sources.
+  - Swift (iOS): detect modules from Xcode project, map view controllers/SwiftUI views and services.
+  - React/Next.js: chunk by component/route boundaries, keep associated hooks and CSS/Styled components together.
+
+- **Function/class-level chunking**
+  - For each supported language, target chunks that keep functions/classes intact, approximating how Dart/TS are handled now.
+
+- **File relationship tracking**
+  - Extend existing file relationships to include:
+    - Android: module dependencies, DI graphs (e.g. Hilt), navigation graphs.
+    - iOS: storyboards/SwiftUI views linked to view models/services.
+    - React/Next.js: component trees, route relationships, API routes → data layer.
+
+**Outcome:** Synthesis can answer questions like "where is the login flow implemented across Android, iOS, and React web?" with high‑quality code navigation.
+
+#### 3.2 GitHub Repo Ingestion & Sync
+
+**Objective:** Move beyond single‑file/URL ingestion to full repo-level ingestion, with incremental updates.
+
+**Key tasks:**
+
+- **Repo ingest pipeline**
+  - Add an ingestion mode for git repositories:
+    - Clone a repo (read‑only) to a local or temp directory.
+    - Walk the tree with language‑aware filters to include/exclude files.
+    - Feed files into the existing extraction/chunking pipeline.
+  - Allow configuration of:
+    - Default branch(es) to index.
+    - Ignored paths (e.g. `node_modules/`, build artifacts).
+
+- **Incremental sync**
+  - Store repo metadata in the DB:
+    - `repo_url`, `default_branch`, `last_ingested_commit`, `last_synced_at`.
+  - When re-syncing:
+    - `git fetch` + `git diff` to find changed/added/deleted files.
+    - Only re-extract and re-embed changed files.
+
+- **Mapping to collections**
+  - Design a clear mapping:
+    - One repo → one collection, or
+    - One project → multiple collections (e.g. docs vs app code vs infra).
+
+- **MCP tools & UI hooks**
+  - MCP tool(s) to:
+    - `add_repo_to_collection` (given repo URL + collectionId).
+    - `sync_repo` to pull latest changes.
+  - UI elements:
+    - "Add repo" form in the collection view.
+    - Status display for last sync and commit.
+
+**Outcome:** Agents can say "sync the main app repo" or "add this new backend repo" and have Synthesis keep them indexed over time.
+
+#### 3.3 Tech-Stack-Aware Collection Profiles
+
+**Objective:** Make each collection explicitly aware of its tech stack, versions, and standards, so retrieval and synthesis can be tuned to that stack.
+
+**Key tasks:**
+
+- **Collection manifest**
+  - Extend `collections` metadata to store:
+    - `primary_languages` (e.g. `['dart', 'typescript']`).
+    - `frameworks` (e.g. `['flutter', 'supabase', 'supabase_flutter', 'redis', 'firebase']`).
+    - Version info where important (e.g. Flutter 3.24.5, Supabase 2.46.1, Redis 7.4.1).
+
+- **Tech-stack detection & confirmation**
+  - Use existing tech detector heuristics for initial guess.
+  - Allow manual overrides: wizard in the UI to confirm stack for a new collection.
+
+- **Retrieval tuning**
+  - When searching within a collection:
+    - Prefer docs/examples that match the collection’s tech stack and major versions.
+    - Down-weight snippets that obviously target incompatible versions or stacks.
+
+- **Profile templates**
+  - Define templates for common stacks:
+    - "Flutter + Supabase + RevenueCat + Firebase Analytics + Sentry + OneSignal + Branch".
+    - "React Native + Supabase + Firebase".
+    - "Next.js + Supabase + Redis".
+  - These templates can preconfigure ingestion sources (official docs, guides, starter repos) and environment parameters.
+
+**Outcome:** New collections can be configured quickly for your stack, and Synthesis can avoid mixing irrelevant tech in its answers.
+
+#### 3.4 Feedback & Evaluation Loop
+
+**Objective:** Add a simple but powerful feedback channel to improve retrieval and synthesis quality over time.
+
+**Key tasks:**
+
+- **Feedback schema**
+  - Add a `feedback` table keyed by search/query or synthesis result:
+    - `id`, `collection_id`, `query`, `result_ids`, `rating` (up/down/score), `comments`, `created_at`, `source` (`user` vs `agent`).
+
+- **UI hooks**
+  - Optional thumbs up/down on search results and synthesis answers.
+  - “Mark as a good example” for particular code snippets.
+
+- **MCP tools**
+  - Tool for agents to record whether a retrieval/synthesis was helpful for a task.
+
+- **Offline analysis**
+  - Later, use this to:
+    - Spot bad snippets.
+    - Adjust scoring heuristics.
+    - Identify missing docs/repos to ingest.
+
+**Outcome:** Over time, your particular workflows (and later, other users’) can tune the system beyond the default ranking.
+
+#### 3.5 Observability & Multi-User Foundations
+
+**Objective:** Prepare Synthesis for use by other coders, not just you.
+
+**Key tasks:**
+
+- **Metrics & logging**
+  - Structured logs for search, ingestion, synthesis, MCP calls.
+  - Metrics for latency, error rates, provider usage per collection and (eventually) per user.
+
+- **Basic auth & tenancy (future)**
+  - Add a user model and simple auth (even just token-based to start).
+  - Map collections and usage to users/teams.
+
+- **Quotas & protections**
+  - Rate limiting on key endpoints.
+  - Soft quotas per user/team for provider usage and storage.
+
+**Outcome:** When you decide to open Synthesis to others, you won’t need a full re-architecture; the hooks will exist for access control and monitoring.
+
+#### 3.6 Agent Workflows Beyond RAG
+
+**Objective:** Make it easier for coding agents to use Synthesis not only to retrieve docs, but to drive actual feature development.
+
+**Key tasks:**
+
+- **Task-oriented MCP tools**
+  - Tools that:
+    - Given a feature request, fetch a minimal context pack from Synthesis (docs + code) for that feature.
+    - Summarize relevant parts of the schema/code for a particular change.
+
+- **Integration with repo ingestion**
+  - When a repo has been ingested, allow agents to:
+    - Ask for “the smallest context needed to implement X” (e.g., existing widgets, blocs, services, DB tables).
+
+- **Planning support**
+  - Generate structured “implementation plans” from Synthesis knowledge that can be fed back into agents as prompts.
+
+**Outcome:** Synthesis becomes an **active collaborator** for your coding agents, not just a doc search engine.
+
+---
+
+### 4. Suggested Phasing (High Level)
+
+This section outlines a rough phase grouping for a future planning agent. Names and numbers are placeholders and should be reconciled with the main roadmap when you’re ready.
+
+- **Phase A – Multi-Language Code Intelligence**
+  - Kotlin/Java Android support, Swift iOS support, better JS/TS heuristics, extended file relationships.
+
+- **Phase B – GitHub Repo Ingestion & Sync**
+  - Repo ingest pipeline, incremental sync, mapping to collections, MCP tools and UI.
+
+- **Phase C – Tech-Stack Profiles for Collections**
+  - Collection manifest, detection/confirmation flow, retrieval tuning, predefined templates for your primary stacks (starting with your Flutter/Supabase example).
+
+- **Phase D – Feedback & Observability**
+  - Feedback schema + UI + MCP tools; core logging and metrics.
+
+- **Phase E – Multi-User & Operational Foundations (Optional, for public use)**
+  - Basic auth, tenancy, quotas, stronger observability.
+
+- **Phase F – Agent Workflow Integrations**
+  - Task-oriented MCP tools and planners built on top of Synthesis.
+
+Each of these phases can be split further into build plans and GitHub issues later. The key is that this roadmap captures **all the extra capabilities** needed to:
+
+- Support your broader tech stacks (Flutter, native mobile, React/Next.js, Node/Python backends, Supabase/Postgres/Redis/Firebase).
+- Ingest and keep large repos in sync.
+- Evolve Synthesis into a platform that both your own agents and other coders can rely on for serious app development.


### PR DESCRIPTION
This PR introduces new planning documents for future work, including the Agent SDK, a potential Desktop App, and Phases 16 and 17. This work was found uncommitted and has been moved to its own branch to keep the v2.0 documentation effort clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Agent SDK migration docs: overview, architecture impact, phased build plan, issue templates, and phase prompts.
  * Added Synthesis Desktop app docs: overview, architecture, build plan, repo/workflow guidance, issue templates, phase prompts, and tech stack.
  * Added Phase 16 & 17 materials: feature-completion/hardening and autonomous ingestion/batch-upload roadmaps, detailed build plans, and issue lists.
  * Added extended tech stack and repo ingestion roadmap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->