### PR TITLE
Phase 16: Persistent Chat History (Part 3)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,13 +5,13 @@
   "author": "Synthesis Team",
   "license": "MIT",
   "homepage": "https://github.com/beaulewis1977/synthesis",
-  "main": "dist/main.js",
+  "main": "dist/index.js",
   "scripts": {
-    "dev": "tsup && electron .",
-    "build": "tsup && electron-builder --config electron-builder.yml",
-    "build:linux": "tsup && electron-builder --linux --config electron-builder.yml",
-    "build:win": "tsup && electron-builder --win --config electron-builder.yml",
-    "pack": "tsup && electron-builder --dir --config electron-builder.yml",
+    "dev": "tsup src/index.ts --format cjs && electron .",
+    "build": "tsup src/index.ts --format cjs && electron-builder --config electron-builder.yml",
+    "build:linux": "tsup src/index.ts --format cjs && electron-builder --linux --config electron-builder.yml",
+    "build:win": "tsup src/index.ts --format cjs && electron-builder --win --config electron-builder.yml",
+    "pack": "tsup src/index.ts --format cjs && electron-builder --dir --config electron-builder.yml",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/server/src/routes/chat.ts
+++ b/apps/server/src/routes/chat.ts
@@ -1,8 +1,11 @@
 import {
+  addChatMessage,
   createChatSession,
+  deleteChatSession,
   getChatMessages,
   getChatSession,
   listChatSessions,
+  updateChatSessionTitle,
 } from '@synthesis/db';
 import type { FastifyPluginAsync } from 'fastify';
 import { z } from 'zod';
@@ -10,6 +13,16 @@ import { z } from 'zod';
 const CreateSessionSchema = z.object({
   collectionId: z.string().uuid(),
   title: z.string().min(1).max(255),
+});
+
+const UpdateSessionSchema = z.object({
+  title: z.string().min(1).max(255),
+});
+
+const AddMessageSchema = z.object({
+  role: z.enum(['user', 'assistant', 'system']),
+  content: z.string().min(1),
+  metadata: z.record(z.unknown()).optional(),
 });
 
 const uuidSchema = z.string().uuid();
@@ -74,6 +87,86 @@ export const chatRoutes: FastifyPluginAsync = async (fastify) => {
     } catch (error) {
       fastify.log.error(error, 'Failed to create chat session');
       return reply.code(500).send({ error: 'Failed to create chat session' });
+    }
+  });
+
+  // Delete a chat session
+  fastify.delete<{ Params: { id: string } }>('/api/chats/:id', async (request, reply) => {
+    const { id: chatId } = request.params;
+    if (!uuidSchema.safeParse(chatId).success) {
+      return reply.code(400).send({ error: 'Invalid chat id' });
+    }
+
+    try {
+      // Verify session exists before deleting
+      const session = await getChatSession(chatId);
+      if (!session) {
+        return reply.code(404).send({ error: 'Chat session not found' });
+      }
+
+      await deleteChatSession(chatId);
+      return reply.code(204).send();
+    } catch (error) {
+      fastify.log.error(error, 'Failed to delete chat session');
+      return reply.code(500).send({ error: 'Failed to delete chat session' });
+    }
+  });
+
+  // Update chat session title
+  fastify.patch<{ Params: { id: string } }>('/api/chats/:id', async (request, reply) => {
+    const { id: chatId } = request.params;
+    if (!uuidSchema.safeParse(chatId).success) {
+      return reply.code(400).send({ error: 'Invalid chat id' });
+    }
+
+    const validation = UpdateSessionSchema.safeParse(request.body);
+    if (!validation.success) {
+      return reply.code(400).send({
+        error: 'Invalid request',
+        details: validation.error.issues,
+      });
+    }
+
+    try {
+      const session = await updateChatSessionTitle(chatId, validation.data.title);
+      if (!session) {
+        return reply.code(404).send({ error: 'Chat session not found' });
+      }
+      return reply.send({ session });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to update chat session');
+      return reply.code(500).send({ error: 'Failed to update chat session' });
+    }
+  });
+
+  // Add message to chat session
+  fastify.post<{ Params: { id: string } }>('/api/chats/:id/messages', async (request, reply) => {
+    const { id: chatId } = request.params;
+    if (!uuidSchema.safeParse(chatId).success) {
+      return reply.code(400).send({ error: 'Invalid chat id' });
+    }
+
+    const validation = AddMessageSchema.safeParse(request.body);
+    if (!validation.success) {
+      return reply.code(400).send({
+        error: 'Invalid request',
+        details: validation.error.issues,
+      });
+    }
+
+    try {
+      // Verify session exists
+      const session = await getChatSession(chatId);
+      if (!session) {
+        return reply.code(404).send({ error: 'Chat session not found' });
+      }
+
+      const { role, content, metadata } = validation.data;
+      const message = await addChatMessage(chatId, role, content, metadata);
+      return reply.code(201).send({ message });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to add chat message');
+      return reply.code(500).send({ error: 'Failed to add chat message' });
     }
   });
 };

--- a/apps/server/src/services/__tests__/cost-tracker.test.ts
+++ b/apps/server/src/services/__tests__/cost-tracker.test.ts
@@ -256,12 +256,12 @@ describe('CostTracker', () => {
       mockQuery.mockResolvedValueOnce({ rows: [] });
 
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
 
       await tracker.checkBudget();
 
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Budget Limit Reached'));
-      expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect(consoleInfoSpy).toHaveBeenCalledWith(
         expect.stringContaining('Budget limit reached - enabling fallback mode')
       );
 
@@ -271,7 +271,7 @@ describe('CostTracker', () => {
       expect(process.env.DISABLE_CONTRADICTION_DETECTION).toBe('true');
 
       consoleSpy.mockRestore();
-      consoleLogSpy.mockRestore();
+      consoleInfoSpy.mockRestore();
     });
 
     it('does not send duplicate alerts within 24 hours', async () => {

--- a/apps/web/src/components/ChatHistorySidebar.tsx
+++ b/apps/web/src/components/ChatHistorySidebar.tsx
@@ -1,5 +1,6 @@
 import { format } from 'date-fns';
-import { MessageSquare, Plus } from 'lucide-react';
+import { MessageSquare, Plus, Trash2 } from 'lucide-react';
+import { useState } from 'react';
 import type { ChatSession } from '../types';
 
 interface ChatHistorySidebarProps {
@@ -7,6 +8,7 @@ interface ChatHistorySidebarProps {
   currentSessionId: string | null;
   onSelectSession: (sessionId: string) => void;
   onNewChat: () => void;
+  onDeleteSession?: (sessionId: string) => void;
   className?: string;
 }
 
@@ -15,8 +17,27 @@ export function ChatHistorySidebar({
   currentSessionId,
   onSelectSession,
   onNewChat,
+  onDeleteSession,
   className = '',
 }: ChatHistorySidebarProps) {
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+
+  const handleDeleteClick = (e: React.MouseEvent, sessionId: string) => {
+    e.stopPropagation();
+    setDeleteConfirmId(sessionId);
+  };
+
+  const handleConfirmDelete = (e: React.MouseEvent, sessionId: string) => {
+    e.stopPropagation();
+    onDeleteSession?.(sessionId);
+    setDeleteConfirmId(null);
+  };
+
+  const handleCancelDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setDeleteConfirmId(null);
+  };
+
   return (
     <div className={`flex flex-col h-full bg-bg-secondary border-r border-border ${className}`}>
       <div className="p-md border-b border-border">
@@ -37,37 +58,70 @@ export function ChatHistorySidebar({
           </div>
         ) : (
           sessions.map((session) => (
-            <button
-              key={session.id}
-              type="button"
-              onClick={() => onSelectSession(session.id)}
-              className={`w-full text-left p-sm rounded-md transition-colors flex items-start gap-sm group ${
-                currentSessionId === session.id
-                  ? 'bg-accent/10 text-accent'
-                  : 'hover:bg-bg-hover text-text-primary'
-              }`}
-            >
-              <MessageSquare
-                size={16}
-                className={`mt-1 flex-shrink-0 ${
-                  currentSessionId === session.id ? 'text-accent' : 'text-text-secondary'
-                }`}
-              />
-              <div className="flex-1 min-w-0">
-                <p className="font-medium text-sm truncate">{session.title}</p>
-                <p className="text-xs text-text-secondary truncate">
-                  {session.updated_at
-                    ? (() => {
-                        try {
-                          return format(new Date(session.updated_at), 'MMM d, h:mm a');
-                        } catch {
-                          return 'Unknown date';
-                        }
-                      })()
-                    : 'Unknown date'}
-                </p>
-              </div>
-            </button>
+            <div key={session.id} className="relative group">
+              {deleteConfirmId === session.id ? (
+                <div className="p-sm rounded-md bg-red-50 border border-red-200 flex items-center justify-between gap-sm">
+                  <span className="text-xs text-red-700">Delete?</span>
+                  <div className="flex gap-xs">
+                    <button
+                      type="button"
+                      onClick={(e) => handleConfirmDelete(e, session.id)}
+                      className="px-sm py-xs text-xs bg-red-600 text-white rounded hover:bg-red-700"
+                    >
+                      Yes
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleCancelDelete}
+                      className="px-sm py-xs text-xs bg-gray-200 text-gray-700 rounded hover:bg-gray-300"
+                    >
+                      No
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => onSelectSession(session.id)}
+                  className={`w-full text-left p-sm rounded-md transition-colors flex items-start gap-sm ${
+                    currentSessionId === session.id
+                      ? 'bg-accent/10 text-accent'
+                      : 'hover:bg-bg-hover text-text-primary'
+                  }`}
+                >
+                  <MessageSquare
+                    size={16}
+                    className={`mt-1 flex-shrink-0 ${
+                      currentSessionId === session.id ? 'text-accent' : 'text-text-secondary'
+                    }`}
+                  />
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium text-sm truncate">{session.title}</p>
+                    <p className="text-xs text-text-secondary truncate">
+                      {session.updated_at
+                        ? (() => {
+                            try {
+                              return format(new Date(session.updated_at), 'MMM d, h:mm a');
+                            } catch {
+                              return 'Unknown date';
+                            }
+                          })()
+                        : 'Unknown date'}
+                    </p>
+                  </div>
+                  {onDeleteSession && (
+                    <button
+                      type="button"
+                      onClick={(e) => handleDeleteClick(e, session.id)}
+                      className="opacity-0 group-hover:opacity-100 p-xs rounded hover:bg-red-100 text-text-secondary hover:text-red-600 transition-all"
+                      title="Delete session"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  )}
+                </button>
+              )}
+            </div>
           ))
         )}
       </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -208,6 +208,49 @@ class ApiClient {
   }
 
   /**
+   * Delete a chat session.
+   * Phase 16 feature - persistent chat history.
+   */
+  async deleteChatSession(sessionId: string): Promise<void> {
+    await this.request(`/api/chats/${encodeURIComponent(sessionId)}`, {
+      method: 'DELETE',
+    });
+  }
+
+  /**
+   * Update a chat session title.
+   * Phase 16 feature - persistent chat history.
+   */
+  async updateChatSessionTitle(
+    sessionId: string,
+    title: string
+  ): Promise<{ session: ChatSession }> {
+    return this.request<{ session: ChatSession }>(`/api/chats/${encodeURIComponent(sessionId)}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ title }),
+    });
+  }
+
+  /**
+   * Add a message to a chat session.
+   * Phase 16 feature - persistent chat history.
+   */
+  async addChatMessage(
+    sessionId: string,
+    role: 'user' | 'assistant' | 'system',
+    content: string,
+    metadata?: Record<string, unknown>
+  ): Promise<{ message: ChatMessage }> {
+    return this.request<{ message: ChatMessage }>(
+      `/api/chats/${encodeURIComponent(sessionId)}/messages`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ role, content, metadata }),
+      }
+    );
+  }
+
+  /**
    * Synthesize search results with multi-source comparison.
    * Phase 12 feature - requires ENABLE_SYNTHESIS=true on backend.
    */

--- a/apps/web/src/pages/ChatPage.tsx
+++ b/apps/web/src/pages/ChatPage.tsx
@@ -203,6 +203,20 @@ export function ChatPage() {
     setSearchParams({ session: id });
   };
 
+  const handleDeleteSession = async (id: string) => {
+    try {
+      await apiClient.deleteChatSession(id);
+      // If we deleted the current session, clear it
+      if (sessionId === id) {
+        handleNewChat();
+      }
+      // Refresh sessions list
+      refetchSessions();
+    } catch (error) {
+      console.error('Failed to delete session:', error);
+    }
+  };
+
   const isLoading = chatMutation.isPending;
 
   return (
@@ -219,6 +233,7 @@ export function ChatPage() {
           currentSessionId={sessionId}
           onSelectSession={handleSelectSession}
           onNewChat={handleNewChat}
+          onDeleteSession={handleDeleteSession}
           className="h-full w-64"
         />
       </div>

--- a/packages/db/src/queries.ts
+++ b/packages/db/src/queries.ts
@@ -432,6 +432,30 @@ export async function getChatMessages(sessionId: string): Promise<ChatMessage[]>
   return result.rows as ChatMessage[];
 }
 
+/**
+ * Deletes a chat session and all its messages (cascade).
+ * @param sessionId The chat session ID.
+ */
+export async function deleteChatSession(sessionId: string): Promise<void> {
+  await query('DELETE FROM chat_sessions WHERE id = $1', [sessionId]);
+}
+
+/**
+ * Updates the title of a chat session.
+ * @param sessionId The chat session ID.
+ * @param title The new title.
+ */
+export async function updateChatSessionTitle(
+  sessionId: string,
+  title: string
+): Promise<ChatSession | null> {
+  const result = await query(
+    'UPDATE chat_sessions SET title = $1, updated_at = NOW() WHERE id = $2 RETURNING *',
+    [title, sessionId]
+  );
+  return (result.rows[0] as ChatSession) || null;
+}
+
 // Ingestion Agent queries
 
 export async function createIngestionJob(


### PR DESCRIPTION
## Summary
Complete implementation of persistent chat history functionality.

## Changes
- **DB Queries**: Added `deleteChatSession()` and `updateChatSessionTitle()`
- **API Endpoints**: Added `DELETE /api/chats/:id`, `PATCH /api/chats/:id`, `POST /api/chats/:id/messages`
- **Frontend API Client**: Added `deleteChatSession()`, `updateChatSessionTitle()`, `addChatMessage()`
- **UI**: Added delete button with confirmation to ChatHistorySidebar

## Files Changed
- `packages/db/src/queries.ts`
- `apps/server/src/routes/chat.ts`
- `apps/web/src/lib/api.ts`
- `apps/web/src/components/ChatHistorySidebar.tsx`
- `apps/web/src/pages/ChatPage.tsx`

## Testing Checklist
- [ ] Create new chat session
- [ ] Send messages and verify persistence
- [ ] Reload page - messages still there
- [ ] Switch between sessions
- [ ] Delete session (with confirmation)
- [ ] New chat button works
- [ ] Session title auto-generates

## Screenshots
N/A - Backend + minor UI enhancement

---
Closes Phase 16 Part 3