### PR TITLE
feat(phase-16a): Claude Agent SDK migration and ChatProvider foundation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,15 +4,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**Synthesis** is an autonomous RAG (Retrieval-Augmented Generation) system powered by Claude Agent SDK for multi-project documentation management. The system enables developers to manage multiple documentation collections, search semantically using pgvector, and interact via a chat UI, MCP server, or external AI agents.
+**Synthesis** is an autonomous RAG (Retrieval-Augmented Generation) system for multi-project documentation management. The system enables developers to manage multiple documentation collections, search semantically using pgvector, and interact via a chat UI, MCP server, or external AI agents.
 
 **Tech Stack:**
 - Backend: Node.js 22, Fastify, TypeScript
 - Frontend: React, Vite, Tailwind CSS
 - Database: PostgreSQL 16 + pgvector 0.7.4
-- AI: Claude Agent SDK (Claude Opus 4 Sonnet), Ollama (local fallback)
-- Embeddings: Multi-provider support (Ollama, OpenAI, Voyage)
+- AI: Anthropic SDK (Claude models), Ollama (local fallback)
+- Embeddings: Multi-provider (Ollama, OpenAI, Voyage)
 - Search: Hybrid search with Reciprocal Rank Fusion (RRF)
+- Caching: Redis for search/rerank caching
 - Deployment: Docker Compose
 - Monorepo: pnpm workspaces + Turbo
 
@@ -20,102 +21,66 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Initial Setup
 ```bash
-# Install dependencies
 pnpm install
+cp .env.example .env  # Configure ANTHROPIC_API_KEY
 
-# Copy environment file and configure API keys
-cp .env.example .env
-# Edit .env with ANTHROPIC_API_KEY and other settings
-
-# Start infrastructure services (PostgreSQL + Ollama)
+# Start infrastructure (PostgreSQL + Ollama + Redis)
 pnpm docker:dev
-# OR: docker compose up -d synthesis-db synthesis-ollama
+# OR: docker compose up -d synthesis-db synthesis-ollama synthesis-redis
 
-# Apply database migrations
+# Apply migrations
 pnpm --filter @synthesis/db migrate
 
-# Pull Ollama models (required for embeddings)
+# Pull Ollama models
 ollama pull nomic-embed-text
 ollama pull llama3.2:3b  # optional for local chat
 ```
 
 ### Development Workflow
 ```bash
-# Start backend server (port 3333)
+# Backend (port 3333)
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/synthesis" \
 ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
 OLLAMA_BASE_URL="http://localhost:11434" \
 STORAGE_PATH="/home/kngpnn/dev/synthesis/storage" \
 pnpm --filter @synthesis/server dev
 
-# Start frontend (port 5173)
+# Frontend (port 5173)
 pnpm --filter @synthesis/web dev
 
-# Start MCP server (optional, for external agents)
+# Desktop app (Tauri)
+pnpm --filter @synthesis/desktop dev
+
+# MCP server (optional)
 pnpm --filter @synthesis/mcp dev
 ```
 
 ### Testing & Quality
 ```bash
-# Run all tests across workspace
-pnpm test
-
-# Run tests in watch mode
-pnpm test:watch
-
-# Type checking
-pnpm typecheck
-
-# Type check specific workspace
-pnpm --filter @synthesis/server typecheck
-pnpm typecheck:server  # shortcut
-
-# Lint & format (uses Biome)
-pnpm lint
-pnpm lint:fix
-pnpm format
-
-# Test coverage
-pnpm test:coverage
+pnpm test              # All tests
+pnpm test:watch        # Watch mode
+pnpm typecheck         # Type checking
+pnpm typecheck:server  # Server only
+pnpm lint && pnpm format
 ```
 
 ### Docker Operations
 ```bash
-# Start only infrastructure (db + ollama)
-pnpm docker:dev
-
-# Start all services including app
-pnpm docker:up
-# OR: docker compose --profile app up -d
-
-# Stop all services
-pnpm docker:down
-
-# View logs
-pnpm docker:logs
+pnpm docker:dev   # Infrastructure only (db + ollama + redis)
+pnpm docker:up    # All services
+pnpm docker:down  # Stop all
+pnpm docker:logs  # View logs
 ```
 
 ### Database Operations
 ```bash
-# Run migrations
 pnpm --filter @synthesis/db migrate
-
-# Connect to database
 docker compose exec synthesis-db psql -U postgres -d synthesis
-
-# Verify pgvector extension
-docker compose exec synthesis-db psql -U postgres -d synthesis -c "\dx"
 ```
 
-### Verification & Health Checks
+### Health Checks
 ```bash
-# Check backend health
 curl http://localhost:3333/health
-
-# Test MCP tools
-pnpm verify:mcp
-
-# Check Ollama
 curl http://localhost:11434/api/tags
 ```
 
@@ -125,341 +90,180 @@ curl http://localhost:11434/api/tags
 ```
 synthesis/
 ├── apps/
-│   ├── server/          # Fastify backend API
-│   ├── web/            # React frontend (Vite)
-│   └── mcp/            # MCP server (Model Context Protocol)
+│   ├── server/     # Fastify backend API
+│   ├── web/        # React frontend (Vite)
+│   ├── desktop/    # Desktop app (Tauri)
+│   └── mcp/        # MCP server
 ├── packages/
-│   ├── db/             # Database client, migrations, queries
-│   └── shared/         # Shared types and utilities
-└── docs/               # Comprehensive planning & phase docs
+│   ├── db/         # Database client, migrations, queries
+│   └── shared/     # Shared types and utilities
+└── docs/           # Planning & phase docs
 ```
 
 ### Key Backend Components (`apps/server/src/`)
 ```
-├── agent/
-│   ├── agent.ts        # Claude Agent SDK orchestrator (10-turn agentic loop)
-│   └── tools.ts        # Agent tool definitions & executors
-├── routes/
-│   ├── agent.ts        # POST /api/agent/chat (chat with agent)
-│   ├── collections.ts  # CRUD for collections
-│   ├── search.ts       # POST /api/search (vector search)
-│   └── ingest.ts       # POST /api/ingest (file upload)
-├── pipeline/
-│   ├── extract.ts      # PDF/DOCX/MD extraction
-│   ├── chunk.ts        # Text chunking (800 chars, 150 overlap)
-│   ├── embed.ts        # Multi-provider embedding orchestration
-│   └── ingest.ts       # Pipeline orchestration
-├── services/
-│   ├── search.ts       # Smart search orchestrator (hybrid/vector modes)
-│   ├── hybrid.ts       # Hybrid search with RRF fusion
-│   ├── vector.ts       # Pure vector similarity search
-│   ├── bm25.ts         # BM25 full-text search
-│   ├── embedding-router.ts  # Provider selection logic
-│   ├── ollama.ts       # Ollama embedding client
-│   ├── openai.ts       # OpenAI embedding client
-│   ├── voyage.ts       # Voyage embedding client
-│   └── scraper.ts      # Web fetching (Playwright)
-└── db/
-    └── queries.ts      # SQL queries for collections/docs/chunks
+├── agent/          # Agent orchestrator & tools
+├── routes/         # HTTP endpoints (collections, search, ingest, chat)
+├── pipeline/       # Extract → Chunk → Embed pipeline
+├── services/       # Search, embeddings, reranking, synthesis
+└── db/             # Server-specific queries
 ```
-
-### Agent System
-The Claude Agent SDK orchestrator (`apps/server/src/agent/agent.ts`) implements a **10-turn agentic loop** with:
-- **Model**: `claude-3-7-sonnet-20250219` (Claude Opus 4 Sonnet)
-- **Max Tokens**: 4096
-- **Tools**: search_rag, add_document, fetch_web_content, list_documents, get_document, delete_document, list_collections, get_collection
-- **Multi-step workflows**: Agent autonomously chains tool calls to complete complex tasks
-- **Context-aware**: Reviews conversation history to avoid repeating metadata
 
 ### Database Schema
 ```sql
 collections (id, name, description, created_at, updated_at)
-documents (id, collection_id, title, file_path, status, metadata JSONB, ...)
+documents (id, collection_id, title, file_path, status, metadata JSONB)
 chunks (id, doc_id, chunk_index, text, embedding VECTOR(768|1024|1536), metadata JSONB)
 ```
-- **Vector index**: HNSW for cosine similarity search
-- **Full-text search**: tsvector column with GIN index for BM25
-- **Cascade deletes**: Collections → Documents → Chunks
-- **Variable dimensions**: Supports 768 (Ollama), 1024 (Voyage), 1536 (OpenAI)
+- **Vector index**: HNSW for cosine similarity
+- **Full-text search**: tsvector with GIN index for BM25
+- **Variable dimensions**: 768 (Ollama), 1024 (Voyage), 1536 (OpenAI)
 
-### Search Architecture (Phase 8)
+### Search Architecture
+- **Vector mode** (default): Query → Embed → pgvector cosine → Top-K
+- **Hybrid mode**: Vector + BM25 → Reciprocal Rank Fusion
+- **Trust scoring** (optional): Boosts by source quality and recency
 
-**Smart Search** (`services/search.ts`) automatically routes to the best search strategy:
+### Multi-Provider Embeddings
+- **Ollama** (nomic-embed-text): Free local, general docs
+- **Voyage** (voyage-code-2): Code documentation
+- **OpenAI** (text-embedding-3-large): Personal writing
+- Auto-detection routes content to appropriate provider
 
-#### Vector-Only Mode (default)
+### RAG Pipeline
 ```
-Query → Embed → pgvector cosine similarity → Top-K results
+Upload → Extract (PDF/DOCX/MD) → Chunk (800 chars) → Provider Selection → Embed → pgvector
 ```
-
-#### Hybrid Mode (SEARCH_MODE=hybrid)
-```
-Query → [Vector Search + BM25 Search] → Reciprocal Rank Fusion → Top-K results
-```
-
-**Reciprocal Rank Fusion (RRF):**
-- Combines vector and BM25 rankings
-- Formula: `score = Σ(weight / (k + rank))`
-- Default k=60, weights: vector=0.7, bm25=0.3
-- Configurable via `HYBRID_VECTOR_WEIGHT` and `HYBRID_BM25_WEIGHT`
-
-**Trust Scoring** (optional, `ENABLE_TRUST_SCORING=true`):
-- Boosts results based on source quality:
-  - Official: 1.0x
-  - Verified: 0.85x
-  - Community: 0.6x
-  - Unknown: 0.5x
-- Applies recency weighting:
-  - <6 months: 1.0x
-  - 6-12 months: 0.9x
-  - >12 months: 0.7x
-
-### Multi-Provider Embeddings (Phase 8)
-
-**Provider Selection** (`services/embedding-router.ts`):
-- **Ollama** (nomic-embed-text, 768 dims): Free local embeddings, good for general docs
-- **OpenAI** (text-embedding-3-large, 1536 dims): Best for personal writing/notes
-- **Voyage** (voyage-code-2, 1024 dims): Optimized for code documentation
-
-**Automatic Content Detection:**
-```typescript
-// Code content → Voyage (CODE_EMBEDDING_PROVIDER)
-if (hasCodePatterns(text) || metadata.doc_type === 'code_sample') {
-  provider = 'voyage';
-}
-
-// Personal writing → OpenAI (WRITING_EMBEDDING_PROVIDER)
-if (metadata.doc_type === 'personal_writing') {
-  provider = 'openai';
-}
-
-// Documentation → Ollama (DOC_EMBEDDING_PROVIDER, default)
-else {
-  provider = 'ollama';
-}
-```
-
-**Code Pattern Detection:**
-- Looks for `import/export`, `class/interface`, `function`, JSX syntax
-- Language hints (Dart, TypeScript, Python, etc.)
-- Automatically routes to code-specialized embeddings
-
-### RAG Pipeline Flow
-```
-Upload → Extract (PDF/DOCX/MD) → Chunk (800 chars, 150 overlap)
-      → Provider Selection → Embed (Ollama/OpenAI/Voyage) → Upsert to pgvector
-```
-
-**Metadata Tracking:**
-- `embedding_provider`: Which provider was used (ollama/openai/voyage)
-- `doc_type`: Content type (code_sample, personal_writing, etc.)
-- `source_quality`: Trust level (official, verified, community)
-- `last_verified`: ISO timestamp for recency scoring
 
 ### MCP Server
-Exposes RAG capabilities to external AI agents (Cursor, Windsurf, Claude Desktop):
-- **stdio mode**: For WSL/IDE agents (JSON-RPC over stdin/stdout)
-- **SSE mode**: For Windows Claude Desktop (Server-Sent Events)
+Exposes RAG to external agents (Cursor, Windsurf, Claude Desktop):
+- **stdio**: WSL/IDE agents
+- **SSE**: Windows Claude Desktop
 
-## Important Implementation Details
-
-### Environment Variables (Phase 8 Updates)
+## Environment Variables
 
 **Required:**
-- `DATABASE_URL`: PostgreSQL connection string
-- `ANTHROPIC_API_KEY`: Required for Claude Agent SDK
-- `OLLAMA_BASE_URL`: Local Ollama endpoint (default: http://localhost:11434)
+- `DATABASE_URL`: PostgreSQL connection
+- `ANTHROPIC_API_KEY`: For Anthropic SDK
+- `OLLAMA_BASE_URL`: Local Ollama (default: http://localhost:11434)
 
-**Search Configuration:**
+**Search:**
 - `SEARCH_MODE`: `vector` (default) or `hybrid`
 - `ENABLE_TRUST_SCORING`: `false` (default) or `true`
-- `HYBRID_VECTOR_WEIGHT`: Default 0.7
-- `HYBRID_BM25_WEIGHT`: Default 0.3
-- `FTS_LANGUAGE`: PostgreSQL full-text search language (default: english)
+- `HYBRID_VECTOR_WEIGHT`/`HYBRID_BM25_WEIGHT`: Default 0.7/0.3
 
-**Embedding Providers:**
-- `DOC_EMBEDDING_PROVIDER`: Default provider for docs (default: ollama)
-- `CODE_EMBEDDING_PROVIDER`: Provider for code (default: voyage)
-- `WRITING_EMBEDDING_PROVIDER`: Provider for personal notes (default: openai)
-- `EMBEDDING_MODEL`: Ollama model name (default: nomic-embed-text)
-- `OPENAI_API_KEY`: Required if using OpenAI provider
-- `VOYAGE_API_KEY`: Required if using Voyage provider
+**Embeddings:**
+- `DOC_EMBEDDING_PROVIDER`: Default ollama
+- `CODE_EMBEDDING_PROVIDER`: Default voyage
+- `WRITING_EMBEDDING_PROVIDER`: Default openai
+- `OPENAI_API_KEY`/`VOYAGE_API_KEY`: If using those providers
 
 **Other:**
-- `STORAGE_PATH`: Local file storage for uploaded documents
-- `SERVER_PORT`, `WEB_PORT`, `MCP_PORT`: Service ports
+- `STORAGE_PATH`: File storage location
+- `REDIS_URL`: Redis for caching (optional)
 
-### Hybrid Search Implementation
+## Skills & Patterns
 
-**Key file:** `apps/server/src/services/hybrid.ts`
+**Project skills** (`.claude/skills/`):
+- `synthesis-architecture` - Routes, services, agent tools, db patterns
+- `llm-provider-integration` - Multi-provider LLM (OpenAI, Anthropic, Google, Ollama, Zhipu, Moonshot)
+- `sse-streaming` - Server-Sent Events for Fastify + React streaming
 
-Hybrid search runs vector and BM25 searches in parallel, then fuses results:
+**Global skills** (useful for this project):
+- `backend-development` - Node.js/Fastify patterns, API design
+- `frontend-design` - React UI components and patterns
+- `gh` - GitHub CLI for PRs and issues
+- `planning` - Breaking down implementation tasks
+- `brainstorming` - Design decisions and alternatives
+- `creating-subagents` - Custom subagents for context efficiency
+
+### Import Patterns
 ```typescript
-const [vectorResults, bm25Results] = await Promise.all([
-  searchCollection(db, { query, collectionId, topK: expandedTopK }),
-  bm25Search(db, { query, collectionId, topK: expandedTopK })
-]);
-
-const fused = fuseResults(vectorResults, bm25Results, weights, rrfK);
+// From apps/server
+import { getPool, query } from '@synthesis/db';
+import { PROVIDER_INFO, ModelFeature } from '@synthesis/shared';
+import { smartSearch } from './services/search.js';
 ```
 
-**RRF Fusion Logic:**
-1. Fetch 3x topK results from each method
-2. Compute RRF score: `1 / (k + rank + 1)` per result per method
-3. Weight scores: `vectorScore * 0.7 + bm25Score * 0.3`
-4. Sort by fused score, return topK
+### Key API Endpoints
+- `POST /api/agent/chat` - Chat with RAG agent
+- `POST /api/search` - Vector/hybrid search
+- `POST /api/ingest` - Upload documents
+- `GET/POST /api/collections` - CRUD collections
+- `GET/POST /api/documents` - CRUD documents
 
-### Embedding Provider Selection
+## Implementation Notes
 
-**Key file:** `apps/server/src/services/embedding-router.ts`
+### Agent System
+The chat agent (`apps/server/src/agent/agent.ts`) implements a 10-turn agentic loop:
+- Tools: search_rag, add_document, fetch_web_content, list_documents, etc.
+- Multi-step workflows with autonomous tool chaining
 
-Provider selection happens at embedding time:
+### Agent Tools
+See `synthesis-architecture` skill for full patterns. Key points:
+- Definitions in `buildAgentTools()` in `tools.ts`
+- Zod schemas for validation
+- Return JSON strings for Claude parsing
+
+### ModelConfigService
+Singleton for model configuration with 60s cache:
 ```typescript
-const config = selectEmbeddingProvider(content, {
-  type: metadata.doc_type,      // 'code' | 'docs' | 'personal'
-  language: metadata.language,   // e.g., 'typescript'
-  isPersonalCollection: true     // personal notes collection flag
-});
-
-// Returns: { provider: 'voyage', model: 'voyage-code-2', dimensions: 1024 }
+import { getModelConfigService } from './services/model-config-service.js';
+const configService = getModelConfigService(db);
+const chatConfig = await configService.getConfig('chat');
+// Returns: { provider: 'anthropic', model: 'claude-...', source: 'db' }
 ```
-
-**Important:** Mixed-provider collections work because search infers the provider from collection metadata and uses the same provider for query embedding.
-
-### Agent Tool Execution
-When implementing or modifying agent tools:
-1. Tool definitions go in `buildAgentTools()` in `apps/server/src/agent/tools.ts`
-2. Each tool has a Zod schema for input validation
-3. Executors are async functions that receive validated input
-4. Return structured results that Claude can parse (prefer JSON strings)
-5. Context (`collectionId`) is passed via tool context
 
 ### Vector Search
-Vector similarity search uses pgvector's cosine distance operator (`<=>`):
 ```sql
-SELECT text, embedding <=> $1::vector AS distance
-FROM chunks
-WHERE doc_id IN (SELECT id FROM documents WHERE collection_id = $2)
-ORDER BY embedding <=> $1::vector
-LIMIT $3
+SELECT text, embedding <=> $1::vector AS distance FROM chunks ...
 ```
-
-**Provider Inference:** Search automatically detects which embedding provider was used for a collection and uses the same provider for query embedding to ensure dimension compatibility.
+Provider auto-inferred from collection metadata for dimension compatibility.
 
 ### File Processing
-- Supported formats: PDF, DOCX, Markdown
-- Max upload size: 100MB (configured in multipart plugin)
-- Storage: Files saved to `${STORAGE_PATH}/${collectionId}/${docId}.*`
-- Status tracking: pending → extracting → chunking → embedding → complete
-- Metadata enrichment: Provider, doc_type, language auto-detected
+- Formats: PDF, DOCX, Markdown
+- Max: 100MB
+- Status: pending → extracting → chunking → embedding → complete
 
-### Testing Strategy
-- Unit tests using Vitest
-- Tests located alongside source files in `__tests__/` directories
-- Coverage target: Critical paths (agent tools, pipeline, search)
-- Mock Anthropic SDK and database in tests
-
-## Common Development Patterns
-
-### Adding a New Agent Tool
-1. Define tool schema and executor in `apps/server/src/agent/tools.ts`
-2. Add to `buildAgentTools()` return value
-3. Update system prompt in `apps/server/src/agent/agent.ts` if needed
-4. Write unit tests in `apps/server/src/agent/__tests__/tools.test.ts`
-
-### Adding a New Embedding Provider
-1. Create client module in `apps/server/src/services/` (see `openai.ts`, `voyage.ts`)
-2. Implement `embed()` function with signature: `(texts: string[]) => Promise<number[][]>`
-3. Add provider config to `PROVIDER_CONFIGS` in `embedding-router.ts`
-4. Update `isEmbeddingProvider()` type guard
-5. Update `.env.example` with new provider config
-
-### Switching Search Modes
-```bash
-# Vector-only (default, fastest)
-SEARCH_MODE=vector
-
-# Hybrid with RRF fusion (better recall)
-SEARCH_MODE=hybrid
-
-# Enable trust scoring (boosts official sources)
-ENABLE_TRUST_SCORING=true
-
-# Adjust hybrid weights (must sum to 1.0)
-HYBRID_VECTOR_WEIGHT=0.8
-HYBRID_BM25_WEIGHT=0.2
-```
-
-### Database Queries
-- Use parameterized queries ($1, $2) to prevent SQL injection
-- Connection pooling via `@synthesis/db` package
-- Always await `pool.query()` calls
-- Handle errors gracefully with try/catch
-
-### Frontend State Management
-- React Query for server state caching
-- React Context for active collection
-- Local state for UI (forms, modals)
-- API client in `apps/web/src/lib/api.ts`
-
-### Adding New Routes
-1. Create route file in `apps/server/src/routes/`
-2. Register with Fastify in `apps/server/src/index.ts`
-3. Use Zod schemas for request validation
-4. Return typed responses with proper error handling
+### Testing
+- Vitest with tests in `__tests__/` directories
+- Mock Anthropic SDK and database
 
 ## Development Notes
 
 ### Phase Progression
-The project has been developed in phases (see `docs/phases/`):
-- **Phase 1-2**: Database + ingestion pipeline
-- **Phase 3**: Agent tools + search
-- **Phase 4**: Autonomous web crawling
-- **Phase 5**: Frontend UI + collections
-- **Phase 6**: MCP server
-- **Phase 7**: Docker integration
-- **Phase 8**: Hybrid search + multi-model embeddings (COMPLETED)
-- **Phase 9**: Reranking + synthesis engine (COMPLETED - Oct 2025)
-- **Phase 10**: Code chunking (COMPLETED - Oct 2025)
-- **Phase 11**: Trust & Recency Badges (COMPLETED - Nov 2025)
-- **Phase 12**: Cost Dashboard & Synthesis View (COMPLETED - Nov 2025)
-- **Phase 13**: Code Intelligence & File Relationships (COMPLETED - Nov 2025)
-- **Phase 14**: Tech Stack Filtering (COMPLETED - Nov 2025)
-- **Phase 15**: Integration & Polish (IN PROGRESS - Nov 2025)
-  - **Day 1**: Integration Testing (COMPLETED - 23 tests, 345 total passing)
-  - **Day 2**: Performance Optimization (COMPLETED - Caching, instrumentation, Prometheus metrics)
-  - **Day 3**: Frontend Polish (IN PROGRESS - Testing complete, UI fixes pending)
-  - **Day 4**: Documentation Updates (PLANNED)
+- **Phase 1-7**: Foundation (DB, pipeline, agent, crawling, UI, MCP, Docker)
+- **Phase 8**: Hybrid search + multi-model embeddings
+- **Phase 9**: Reranking + synthesis engine
+- **Phase 10**: Code chunking
+- **Phase 11**: Trust & Recency Badges
+- **Phase 12**: Cost Dashboard & Synthesis View
+- **Phase 13**: Code Intelligence & File Relationships
+- **Phase 14**: Tech Stack Filtering
+- **Phase 15**: Integration & Polish (COMPLETED)
+- **Phase 16**: Multi-Provider Chat & UI Improvements (IN PROGRESS)
 
-### Current Branch Strategy
-- Feature branches: `feature/phase-X-description` or `feat/phase-X-description`
-- Main branch: `develop`
-- No explicit main branch configured (local development focused)
+### Branch Strategy
+- Feature branches: `feature/phase-X-description`
+- Integration branch: `develop`
+- All work branches off `develop`
 
-### Current Development Status (Phase 15)
-- **Active Branch**: `feat/phase-15-day-3-frontend-polish`
-- **Latest Merged**: Phase 15 Day 2 (PR #105 - Performance Optimization)
-- **In Progress**: Phase 15 Day 3 - Frontend Polish & Accessibility
-  - Testing infrastructure: 15 Playwright E2E tests passing (mobile, keyboard, accessibility)
-  - Issues identified: 8 color contrast failures, 4 touch target issues, Lighthouse performance 56
-  - Remaining work: Color adjustments, touch target sizing, bundle optimization, manual testing
+### Current Status
+- **Active Branch**: `feature/phase-16-multi-provider-chat`
+- **Focus**: Multi-provider chat (Anthropic, OpenAI, Ollama, Google, GLM, Kimi), SSE streaming, UI improvements
 
-### Performance Considerations
-- Ollama embeddings: ~50 chunks/sec with GPU
-- OpenAI embeddings: ~100 chunks/sec (API limit dependent)
-- Voyage embeddings: ~80 chunks/sec (API limit dependent)
-- Vector search: <500ms with HNSW index
-- Hybrid search: ~800ms (parallel vector + BM25)
-- Agent multi-step: <10 seconds for 3-step workflows
-- Consider batch embedding for large documents (all providers support batching)
+### Performance
+- Ollama embeddings: ~50 chunks/sec (GPU)
+- Vector search: <500ms (HNSW)
+- Hybrid search: ~800ms (parallel)
+- Agent multi-step: <10s for 3-step workflows
 
-### Known Limitations (Current)
+### Known Limitations
 - No authentication (local use only)
-- No background job queue (synchronous processing)
-- No query caching (Redis planned for Phase 2+)
+- No background job queue (synchronous)
 - Single Postgres/Ollama instance
-- BM25 requires PostgreSQL full-text search setup (applied via migrations)
 
-### Troubleshooting
+## Troubleshooting
 
 **Ollama not responding:**
 ```bash
@@ -476,7 +280,6 @@ docker compose logs synthesis-db
 **pgvector errors:**
 ```sql
 CREATE EXTENSION IF NOT EXISTS vector;
-\dx
 ```
 
 **Port conflicts:**
@@ -486,45 +289,16 @@ kill -9 <PID>
 ```
 
 **Mixed provider dimension errors:**
-- Ensure query uses same provider as collection documents
 - Check `embedding_provider` in document metadata
-- Smart search automatically handles this via `inferCollectionEmbeddingHint()`
+- Smart search handles this via `inferCollectionEmbeddingHint()`
 
 **BM25 not working:**
 ```sql
--- Verify tsvector column exists
-\d chunks
-
--- Check if GIN index exists
-\di chunks_fts_idx
+\d chunks  -- Verify tsvector column
+\di chunks_fts_idx  -- Check GIN index
 ```
-
-## Key Documentation Files
-
-For deeper understanding of specific areas:
-- Architecture: `docs/02_ARCHITECTURE.md`
-- Database schema: `docs/03_DATABASE_SCHEMA.md`
-- Agent tools specification: `docs/04_AGENT_TOOLS.md`
-- API specification: `docs/05_API_SPEC.md`
-- RAG pipeline: `docs/06_PIPELINE.md`
-- Environment setup: `docs/10_ENV_SETUP.md`
-- Phase 8 overview: `docs/phases/phase-8/00_PHASE_8_OVERVIEW.md`
-- Hybrid search architecture: `docs/phases/phase-8/01_HYBRID_SEARCH_ARCHITECTURE.md`
-- Embedding providers: `docs/phases/phase-8/02_EMBEDDING_PROVIDERS.md`
-- Trust scoring: `docs/phases/phase-8/04_TRUST_SCORING.md`
-- Phase details: `docs/phases/`
-
-## Critical Code Locations
-
-- Agent orchestrator: `apps/server/src/agent/agent.ts:94` (runAgentChat function)
-- Tool definitions: `apps/server/src/agent/tools.ts`
-- Smart search orchestrator: `apps/server/src/services/search.ts:42` (smartSearch function)
-- Hybrid search with RRF: `apps/server/src/services/hybrid.ts:26` (hybridSearch function)
-- RRF fusion logic: `apps/server/src/services/hybrid.ts:72` (fuseResults function)
-- Provider selection: `apps/server/src/services/embedding-router.ts:45` (selectEmbeddingProvider)
-- Code detection: `apps/server/src/services/embedding-router.ts:83` (isCodeContent)
-- Trust scoring: `apps/server/src/services/search.ts:202` (applyTrustScoring)
-- Vector search logic: `apps/server/src/services/vector.ts`
-- Database pool initialization: `apps/server/src/index.ts:22-27`
-- RAG pipeline: `apps/server/src/pipeline/ingest.ts`
-- Migration runner: `packages/db/src/migrate.ts`
+- all branches must be off of develop and all pr's will be to develop for merging after i review them
+- don't commit or push without my permission, ever
+- always look for specialized subagents or create subagents with the subagent skill to save on context window bloat
+- be sure to use context7 mcp server when needed
+- when having trouble- stop, take a deep breath and then research, web search, plan, then fix

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.1.59",
     "@anthropic-ai/sdk": "^0.65.0",
     "@fastify/compress": "^7.0.1",
     "@fastify/cors": "^9.0.1",

--- a/apps/server/src/__tests__/claude-sdk-workaround.test.ts
+++ b/apps/server/src/__tests__/claude-sdk-workaround.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Claude Agent SDK Workaround Test
+ *
+ * Phase 16A: Test if Claude Agent SDK works with existing Claude Code CLI on WSL2.
+ *
+ * Known issue: https://github.com/anthropics/claude-agent-sdk-typescript/issues/20
+ * The SDK's bundled binary crashes on WSL2. This test checks if pointing to
+ * an existing Claude Code installation works around the issue.
+ *
+ * Run with: pnpm --filter @synthesis/server test src/__tests__/claude-sdk-workaround.test.ts
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// Path to existing Claude Code CLI (installed via pnpm)
+const CLAUDE_CLI_PATH = '/home/kngpnn/.local/share/pnpm/claude';
+
+describe('Claude Agent SDK WSL2 Workaround', () => {
+  describe('Prerequisites', () => {
+    it('should have Claude CLI installed at expected path', () => {
+      expect(existsSync(CLAUDE_CLI_PATH)).toBe(true);
+    });
+
+    it('should have ANTHROPIC_API_KEY environment variable set', () => {
+      expect(process.env.ANTHROPIC_API_KEY).toBeDefined();
+      expect(process.env.ANTHROPIC_API_KEY?.length).toBeGreaterThan(0);
+    });
+
+    it('should be able to execute Claude CLI --version', () => {
+      const result = execSync(`${CLAUDE_CLI_PATH} --version`, {
+        encoding: 'utf8',
+        timeout: 10000,
+      });
+      expect(result).toContain('Claude Code');
+      console.info('Claude CLI version:', result.trim());
+    });
+  });
+
+  describe('Agent SDK Import', () => {
+    it('should be able to import @anthropic-ai/claude-agent-sdk', async () => {
+      const sdk = await import('@anthropic-ai/claude-agent-sdk');
+      expect(sdk.query).toBeDefined();
+      expect(typeof sdk.query).toBe('function');
+      console.info('Agent SDK imported successfully');
+      console.info('Available exports:', Object.keys(sdk));
+    });
+  });
+
+  describe('Agent Query with Custom CLI Path', () => {
+    it('should create a query with pathToClaudeCodeExecutable', async () => {
+      const { query } = await import('@anthropic-ai/claude-agent-sdk');
+
+      // Create query with custom CLI path - this tests if it can start without WSL2 crash
+      const q = query({
+        prompt: 'Say exactly "OK" and nothing else.',
+        options: {
+          pathToClaudeCodeExecutable: CLAUDE_CLI_PATH,
+          systemPrompt: 'You are a test agent. Respond with exactly "OK" to any message.',
+          permissionMode: 'bypassPermissions',
+          allowDangerouslySkipPermissions: true,
+        },
+      });
+
+      expect(q).toBeDefined();
+      console.info('Query created successfully with custom CLI path');
+    });
+
+    it('should execute a simple query without WSL2 crash', async () => {
+      const { query } = await import('@anthropic-ai/claude-agent-sdk');
+
+      const abortController = new AbortController();
+
+      // Set timeout to abort after 30 seconds
+      const timeout = setTimeout(() => {
+        abortController.abort();
+      }, 30000);
+
+      try {
+        const q = query({
+          prompt: 'Say exactly "OK" and nothing else.',
+          options: {
+            pathToClaudeCodeExecutable: CLAUDE_CLI_PATH,
+            systemPrompt: 'You are a test agent. Respond with exactly "OK" to any message.',
+            permissionMode: 'bypassPermissions',
+            allowDangerouslySkipPermissions: true,
+            abortController,
+          },
+        });
+
+        // Iterate through the query results
+        let responseText = '';
+        for await (const message of q) {
+          console.info('Message type:', message.type);
+          if (message.type === 'assistant') {
+            responseText += message.message.content
+              .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
+              .map((block) => block.text)
+              .join('');
+          }
+        }
+
+        clearTimeout(timeout);
+
+        console.info('Response received:', responseText);
+        expect(responseText.length).toBeGreaterThan(0);
+        console.info('SUCCESS: Agent SDK works with custom CLI path on WSL2!');
+      } catch (error) {
+        clearTimeout(timeout);
+        const errorMessage = (error as Error).message;
+        console.error('Agent query failed:', errorMessage);
+
+        // Check if it's the known WSL2 crash issue
+        if (
+          errorMessage.includes('ENOENT') ||
+          errorMessage.includes('spawn') ||
+          errorMessage.includes('binary')
+        ) {
+          console.info('FAILURE: WSL2 binary issue detected. Need Docker fallback.');
+        }
+
+        // Re-throw to fail the test
+        throw error;
+      }
+    }, 60000); // 60 second timeout for API call
+  });
+});
+
+/**
+ * Manual Test Instructions
+ *
+ * If the automated test cannot run, test manually:
+ *
+ * 1. Create a simple test script:
+ *    ```typescript
+ *    import { query } from '@anthropic-ai/claude-agent-sdk';
+ *
+ *    const q = query({
+ *      prompt: 'Say OK',
+ *      options: {
+ *        pathToClaudeCodeExecutable: '/home/kngpnn/.local/share/pnpm/claude',
+ *        systemPrompt: 'Respond with OK',
+ *        permissionMode: 'bypassPermissions',
+ *        allowDangerouslySkipPermissions: true,
+ *      },
+ *    });
+ *
+ *    for await (const msg of q) {
+ *      console.info(msg);
+ *    }
+ *    ```
+ *
+ * 2. Expected outcomes:
+ *    - SUCCESS: Query returns messages without crash
+ *    - FAILURE: Process crashes with ENOENT/spawn error → Need Docker
+ */

--- a/apps/server/src/agent/__tests__/agent.test.ts
+++ b/apps/server/src/agent/__tests__/agent.test.ts
@@ -1,42 +1,81 @@
 import type { Pool } from 'pg';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const anthropicCreateMock = vi.hoisted(() => vi.fn());
-const searchExecutorMock = vi.hoisted(() =>
-  vi.fn().mockResolvedValue('Tool search_rag executed successfully.')
-);
-const buildAgentToolsMock = vi.hoisted(() =>
-  vi.fn(() => ({
-    tools: [
-      {
-        name: 'search_rag',
-        description: 'mock tool',
-        input_schema: { type: 'object', properties: {} },
-      },
-    ],
-    toolExecutors: {
-      search_rag: searchExecutorMock,
-    },
+// =============================================================================
+// Mocks for Claude Agent SDK
+// =============================================================================
+
+const queryMock = vi.hoisted(() => vi.fn());
+const createSdkMcpServerMock = vi.hoisted(() => vi.fn(() => ({})));
+const toolMock = vi.hoisted(() =>
+  vi.fn((name: string, _desc: string, _schema: unknown, handler: unknown) => ({
+    name,
+    handler,
   }))
 );
 
-vi.mock('@anthropic-ai/sdk', () => ({
+const buildAgentMcpServerMock = vi.hoisted(() => vi.fn(() => ({})));
+const MCP_SERVER_NAME_MOCK = 'synthesis-rag-tools';
+const MCP_TOOL_NAMES_MOCK = [
+  'mcp__synthesis-rag-tools__search_rag',
+  'mcp__synthesis-rag-tools__add_document',
+  'mcp__synthesis-rag-tools__fetch_web_content',
+  'mcp__synthesis-rag-tools__list_collections',
+  'mcp__synthesis-rag-tools__list_documents',
+  'mcp__synthesis-rag-tools__get_document_status',
+  'mcp__synthesis-rag-tools__delete_document',
+  'mcp__synthesis-rag-tools__restart_ingest',
+  'mcp__synthesis-rag-tools__summarize_document',
+];
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
   __esModule: true,
-  default: vi.fn().mockImplementation(() => ({
-    messages: {
-      create: anthropicCreateMock,
-    },
-  })),
+  query: queryMock,
+  createSdkMcpServer: createSdkMcpServerMock,
+  tool: toolMock,
 }));
 
 vi.mock(
   '../tools.js',
   () => ({
     __esModule: true,
-    buildAgentTools: buildAgentToolsMock,
+    buildAgentMcpServer: buildAgentMcpServerMock,
+    MCP_SERVER_NAME: MCP_SERVER_NAME_MOCK,
+    MCP_TOOL_NAMES: MCP_TOOL_NAMES_MOCK,
   }),
   { virtual: true }
 );
+
+// =============================================================================
+// Helper to create mock async generator
+// =============================================================================
+
+interface MockMessage {
+  type: string;
+  subtype?: string;
+  session_id?: string;
+  message?: {
+    content: unknown;
+  };
+  result?: string;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+  };
+  total_cost_usd?: number;
+  num_turns?: number;
+  duration_ms?: number;
+}
+
+async function* mockQueryGenerator(messages: MockMessage[]) {
+  for (const msg of messages) {
+    yield msg;
+  }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
 
 let runAgentChat: typeof import('../agent.js')['runAgentChat'];
 
@@ -51,40 +90,73 @@ describe('runAgentChat', () => {
     process.env.ANTHROPIC_API_KEY = 'test-key';
     vi.clearAllMocks();
 
-    anthropicCreateMock
-      .mockResolvedValueOnce({
-        content: [
-          {
-            type: 'tool_use',
-            id: 'tool-1',
-            name: 'search_rag',
-            input: { query: 'What is pgvector?' },
+    // Default mock: successful query with tool call
+    queryMock.mockReturnValue(
+      mockQueryGenerator([
+        // Session init
+        { type: 'system', subtype: 'init', session_id: 'sess-123' },
+        // Assistant makes a tool call
+        {
+          type: 'user',
+          message: {
+            content: [
+              {
+                type: 'tool_use',
+                id: 'tool-1',
+                name: 'mcp__synthesis-rag-tools__search_rag',
+                input: { query: 'What is pgvector?' },
+              },
+            ],
           },
-        ],
-        usage: {
-          input_tokens: 50,
-          output_tokens: 10,
         },
-      })
-      .mockResolvedValueOnce({
-        content: [
-          {
-            type: 'text',
-            text: 'pgvector is a PostgreSQL extension for vector similarity search.',
+        // Tool result
+        {
+          type: 'user',
+          message: {
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'tool-1',
+                content: [{ type: 'text', text: 'Search results for pgvector...' }],
+                is_error: false,
+              },
+            ],
           },
-        ],
-        usage: {
-          input_tokens: 20,
-          output_tokens: 30,
         },
-      });
+        // Assistant final response
+        {
+          type: 'assistant',
+          message: {
+            content: [
+              {
+                type: 'text',
+                text: 'pgvector is a PostgreSQL extension for vector similarity search.',
+              },
+            ],
+          },
+        },
+        // Final result with usage
+        {
+          type: 'result',
+          subtype: 'success',
+          result: 'pgvector is a PostgreSQL extension for vector similarity search.',
+          usage: {
+            input_tokens: 70,
+            output_tokens: 40,
+          },
+          total_cost_usd: 0.001,
+          num_turns: 2,
+          duration_ms: 1500,
+        },
+      ])
+    );
   });
 
   afterEach(() => {
     Reflect.deleteProperty(process.env, 'ANTHROPIC_API_KEY');
   });
 
-  it('runs the agent loop, executes tools, and returns final response', async () => {
+  it('runs the agent loop using SDK, executes tools, and returns final response', async () => {
     const history = [{ role: 'user' as const, content: 'Previous question' }];
 
     const result = await runAgentChat(db, {
@@ -93,25 +165,47 @@ describe('runAgentChat', () => {
       history,
     });
 
-    expect(buildAgentToolsMock).toHaveBeenCalledWith(db, {
+    // Verify MCP server was built
+    expect(buildAgentMcpServerMock).toHaveBeenCalledWith(db, {
       collectionId: '11111111-1111-4111-8111-111111111111',
     });
 
-    expect(anthropicCreateMock).toHaveBeenCalledTimes(2);
-    expect(searchExecutorMock).toHaveBeenCalledWith({ query: 'What is pgvector?' });
+    // Verify query was called with correct options
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining('Tell me about pgvector'),
+        options: expect.objectContaining({
+          maxTurns: 10,
+          permissionMode: 'bypassPermissions',
+          mcpServers: expect.any(Object),
+          allowedTools: expect.arrayContaining(['mcp__synthesis-rag-tools__search_rag']),
+        }),
+      })
+    );
 
+    // Verify result structure
     expect(result.message).toBe('pgvector is a PostgreSQL extension for vector similarity search.');
     expect(result.toolCalls).toHaveLength(1);
     expect(result.toolCalls[0]).toMatchObject({
       id: 'tool-1',
-      tool: 'search_rag',
+      tool: 'search_rag', // Should be extracted from full MCP name
       status: 'completed',
-      result: 'Tool search_rag executed successfully.',
     });
 
+    // Verify usage tracking
     expect(result.usage).toEqual({
       input_tokens: 70,
       output_tokens: 40,
+      total_cost_usd: 0.001,
+      num_turns: 2,
+      duration_ms: 1500,
+    });
+
+    // Verify history updated
+    expect(result.history).toHaveLength(3);
+    expect(result.history[result.history.length - 1]).toMatchObject({
+      role: 'assistant',
+      content: 'pgvector is a PostgreSQL extension for vector similarity search.',
     });
   });
 
@@ -124,5 +218,132 @@ describe('runAgentChat', () => {
         collectionId: '11111111-1111-4111-8111-111111111111',
       })
     ).rejects.toThrow(/ANTHROPIC_API_KEY/);
+  });
+
+  it('handles query without tool calls', async () => {
+    queryMock.mockReturnValue(
+      mockQueryGenerator([
+        { type: 'system', subtype: 'init', session_id: 'sess-456' },
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'Hello! How can I help you today?' }],
+          },
+        },
+        {
+          type: 'result',
+          subtype: 'success',
+          result: 'Hello! How can I help you today?',
+          usage: { input_tokens: 20, output_tokens: 10 },
+          total_cost_usd: 0.0001,
+          num_turns: 1,
+          duration_ms: 500,
+        },
+      ])
+    );
+
+    const result = await runAgentChat(db, {
+      message: 'Hello',
+      collectionId: '11111111-1111-4111-8111-111111111111',
+    });
+
+    expect(result.message).toBe('Hello! How can I help you today?');
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.usage).toMatchObject({
+      input_tokens: 20,
+      output_tokens: 10,
+    });
+  });
+
+  it('handles tool errors gracefully', async () => {
+    queryMock.mockReturnValue(
+      mockQueryGenerator([
+        { type: 'system', subtype: 'init', session_id: 'sess-789' },
+        {
+          type: 'user',
+          message: {
+            content: [
+              {
+                type: 'tool_use',
+                id: 'tool-err',
+                name: 'mcp__synthesis-rag-tools__search_rag',
+                input: { query: 'test' },
+              },
+            ],
+          },
+        },
+        {
+          type: 'user',
+          message: {
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'tool-err',
+                content: [{ type: 'text', text: 'Database connection failed' }],
+                is_error: true,
+              },
+            ],
+          },
+        },
+        {
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'text', text: 'I encountered an error while searching. Please try again.' },
+            ],
+          },
+        },
+        {
+          type: 'result',
+          subtype: 'success',
+          result: 'I encountered an error while searching. Please try again.',
+          usage: { input_tokens: 30, output_tokens: 20 },
+          total_cost_usd: 0.0002,
+          num_turns: 2,
+          duration_ms: 800,
+        },
+      ])
+    );
+
+    const result = await runAgentChat(db, {
+      message: 'Search for something',
+      collectionId: '11111111-1111-4111-8111-111111111111',
+    });
+
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0].status).toBe('error');
+    expect(result.message).toContain('error');
+  });
+
+  it('handles max turns exceeded', async () => {
+    queryMock.mockReturnValue(
+      mockQueryGenerator([
+        { type: 'system', subtype: 'init', session_id: 'sess-max' },
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'Working on it...' }],
+          },
+        },
+        {
+          type: 'result',
+          subtype: 'error_max_turns',
+          usage: { input_tokens: 500, output_tokens: 300 },
+          num_turns: 10,
+        },
+      ])
+    );
+
+    const result = await runAgentChat(db, {
+      message: 'Complex task',
+      collectionId: '11111111-1111-4111-8111-111111111111',
+    });
+
+    expect(result.message).toBe('Working on it...');
+    expect(result.usage).toMatchObject({
+      input_tokens: 500,
+      output_tokens: 300,
+      num_turns: 10,
+    });
   });
 });

--- a/apps/server/src/agent/__tests__/tools.test.ts
+++ b/apps/server/src/agent/__tests__/tools.test.ts
@@ -1,6 +1,9 @@
 import type { Pool } from 'pg';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  MCP_SERVER_NAME,
+  MCP_TOOL_NAMES,
+  buildAgentMcpServer,
   buildAgentTools,
   createAddDocumentTool,
   createDeleteDocumentTool,
@@ -356,5 +359,49 @@ describe('agent tools', () => {
     for (const name of expectedNames) {
       expect(typeof toolExecutors[name]).toBe('function');
     }
+  });
+});
+
+// =============================================================================
+// MCP Server Format Tests (for Claude Agent SDK)
+// =============================================================================
+
+describe('MCP Server format', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('MCP_SERVER_NAME is correctly defined', () => {
+    expect(MCP_SERVER_NAME).toBe('synthesis-rag-tools');
+  });
+
+  it('MCP_TOOL_NAMES includes all expected tools', () => {
+    const expectedToolNames = [
+      'mcp__synthesis-rag-tools__search_rag',
+      'mcp__synthesis-rag-tools__add_document',
+      'mcp__synthesis-rag-tools__fetch_web_content',
+      'mcp__synthesis-rag-tools__list_collections',
+      'mcp__synthesis-rag-tools__list_documents',
+      'mcp__synthesis-rag-tools__get_document_status',
+      'mcp__synthesis-rag-tools__delete_document',
+      'mcp__synthesis-rag-tools__restart_ingest',
+      'mcp__synthesis-rag-tools__summarize_document',
+    ];
+
+    expect(MCP_TOOL_NAMES).toEqual(expectedToolNames);
+    expect(MCP_TOOL_NAMES.length).toBe(9);
+  });
+
+  it('buildAgentMcpServer returns a valid MCP server object', () => {
+    const db = createDbMock();
+    const server = buildAgentMcpServer(db, {
+      collectionId: '11111111-1111-4111-8111-111111111111',
+    });
+
+    // Server should be defined - SDK returns an object with type: 'sdk'
+    expect(server).toBeDefined();
+    expect(typeof server).toBe('object');
+    // The SDK wraps the server with type: 'sdk' property
+    expect(server).toHaveProperty('type', 'sdk');
   });
 });

--- a/apps/server/src/agent/agent.ts
+++ b/apps/server/src/agent/agent.ts
@@ -1,8 +1,11 @@
-import Anthropic from '@anthropic-ai/sdk';
-import type { ContentBlock, MessageParam, Tool } from '@anthropic-ai/sdk/resources/messages.js';
+import { query } from '@anthropic-ai/claude-agent-sdk';
 import type { Pool } from 'pg';
 import { getModelConfigService } from '../services/model-config-service.js';
-import { buildAgentTools } from './tools.js';
+import { MCP_SERVER_NAME, MCP_TOOL_NAMES, buildAgentMcpServer } from './tools.js';
+
+// =============================================================================
+// Types
+// =============================================================================
 
 export interface AgentConversationMessage {
   role: 'user' | 'assistant';
@@ -30,6 +33,13 @@ export interface AgentChatResult {
   history: AgentConversationMessage[];
   usage?: Record<string, unknown>;
 }
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+/** Path to Claude CLI executable (required for SDK on WSL2) */
+const CLAUDE_CLI_PATH = process.env.CLAUDE_CLI_PATH || 'claude';
 
 const BASE_SYSTEM_PROMPT = `You are an autonomous RAG assistant helping a developer manage documentation for multiple projects.
 
@@ -70,6 +80,13 @@ MCP Tool Selection:
 
 For complex tasks, chain tools: get_feature_recipe → find_code_examples → search_mobile_docs`;
 
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Build the prompt with context for the agent
+ */
 function buildPrompt(
   message: string,
   collectionId: string,
@@ -91,180 +108,166 @@ function buildPrompt(
   return sections.join('\n\n');
 }
 
-function extractTextFromContent(content: ContentBlock[]): string {
-  const textParts: string[] = [];
-  for (const block of content) {
-    if (block.type === 'text') {
-      textParts.push(block.text);
-    }
-  }
-  return textParts.join('\n').trim();
+/**
+ * Extract the tool name without the MCP prefix
+ */
+function extractToolName(fullName: string): string {
+  // Format: mcp__synthesis-rag-tools__search_rag → search_rag
+  const prefix = `mcp__${MCP_SERVER_NAME}__`;
+  return fullName.startsWith(prefix) ? fullName.slice(prefix.length) : fullName;
 }
 
-function convertHistoryToMessages(history: AgentConversationMessage[]): MessageParam[] {
-  return history.map((msg) => ({
-    role: msg.role,
-    content: msg.content,
-  }));
-}
+// =============================================================================
+// Main Agent Function
+// =============================================================================
 
+/**
+ * Run an agent chat using the Claude Agent SDK.
+ *
+ * This replaces the manual 10-turn agentic loop with the SDK's query() function,
+ * which handles tool execution automatically.
+ */
 export async function runAgentChat(db: Pool, params: AgentChatParams): Promise<AgentChatResult> {
   // Get chat model configuration
   const modelConfigService = getModelConfigService(db);
   const chatConfig = await modelConfigService.getChatModelConfig();
 
-  // Validate API key for the configured provider
+  // Validate API key for Anthropic provider
   if (chatConfig.provider === 'anthropic' && !process.env.ANTHROPIC_API_KEY) {
     throw new Error('ANTHROPIC_API_KEY environment variable must be set to use the agent.');
   }
 
-  const anthropic = new Anthropic({
-    apiKey: process.env.ANTHROPIC_API_KEY,
-  });
-
   const history = params.history ?? [];
-  const { tools: toolDefinitions, toolExecutors } = buildAgentTools(db, {
-    collectionId: params.collectionId,
-  });
 
+  // Build MCP server with all RAG tools
+  const mcpServer = buildAgentMcpServer(db, { collectionId: params.collectionId });
+
+  // Build system prompt with collection context
   const systemPrompt = `${BASE_SYSTEM_PROMPT}\n\nActive collection ID: ${params.collectionId}`;
-  const messages: MessageParam[] = [
-    ...convertHistoryToMessages(history),
-    { role: 'user', content: buildPrompt(params.message, params.collectionId, history) },
-  ];
 
+  // Build user prompt with history context
+  const prompt = buildPrompt(params.message, params.collectionId, history);
+
+  // Track tool calls and results
   const toolCalls: AgentToolCall[] = [];
   let assistantMessage = '';
   let totalUsage: Record<string, unknown> = {};
 
-  const maxTurns = 10;
-  let turn = 0;
-
-  while (turn < maxTurns) {
-    turn++;
-
-    const response = await anthropic.messages.create({
-      model: chatConfig.model,
-      max_tokens: 4096,
-      system: systemPrompt,
-      messages,
-      tools: toolDefinitions as Tool[],
-    });
-
-    // Accumulate usage
-    if (response.usage) {
-      totalUsage = {
-        input_tokens:
-          ((totalUsage.input_tokens as number) ?? 0) + (response.usage.input_tokens ?? 0),
-        output_tokens:
-          ((totalUsage.output_tokens as number) ?? 0) + (response.usage.output_tokens ?? 0),
-      };
-    }
-
-    // Extract text content
-    const textContent = extractTextFromContent(response.content);
-    if (textContent) {
-      assistantMessage = textContent;
-    }
-
-    // Check for tool uses
-    const toolUseBlocks = response.content.filter((block) => block.type === 'tool_use');
-
-    if (toolUseBlocks.length === 0) {
-      // No tools called, conversation is complete
-      break;
-    }
-
-    // Add assistant's response with tool calls to messages
-    messages.push({
-      role: 'assistant',
-      content: response.content,
-    });
-
-    // Execute tools and collect results
-    const toolResults: Array<{
-      type: 'tool_result';
-      tool_use_id: string;
-      content: string;
-      is_error?: boolean;
-    }> = [];
-
-    for (const toolUse of toolUseBlocks) {
-      if (toolUse.type !== 'tool_use') continue;
-
-      const toolCall: AgentToolCall = {
-        id: toolUse.id,
-        tool: toolUse.name,
-        input: toolUse.input,
-        status: 'started',
-      };
-
-      toolCalls.push(toolCall);
-
-      try {
-        const executor = toolExecutors[toolUse.name];
-        if (!executor) {
-          throw new Error(`Tool ${toolUse.name} not found`);
-        }
-
-        const result = await executor(toolUse.input);
-        const resultText = extractToolResultContent(result);
-
-        toolCall.status = 'completed';
-        toolCall.result = resultText;
-
-        toolResults.push({
-          type: 'tool_result',
-          tool_use_id: toolUse.id,
-          content: resultText,
-        });
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-        toolCall.status = 'error';
-        toolCall.result = errorMessage;
-
-        toolResults.push({
-          type: 'tool_result',
-          tool_use_id: toolUse.id,
-          content: errorMessage,
-          is_error: true,
-        });
-      }
-    }
-
-    // Add tool results to messages
-    messages.push({
-      role: 'user',
-      content: toolResults,
-    });
-
-    // If this was the last turn, get one more response from Claude
-    if (turn === maxTurns) {
-      const finalResponse = await anthropic.messages.create({
+  try {
+    // Use Claude Agent SDK query()
+    const response = query({
+      prompt,
+      options: {
+        pathToClaudeCodeExecutable: CLAUDE_CLI_PATH,
+        systemPrompt,
         model: chatConfig.model,
-        max_tokens: 4096,
-        system: systemPrompt,
-        messages,
-        tools: toolDefinitions as Tool[],
-      });
+        mcpServers: {
+          [MCP_SERVER_NAME]: mcpServer,
+        },
+        allowedTools: [...MCP_TOOL_NAMES],
+        permissionMode: 'bypassPermissions',
+        maxTurns: 10,
+      },
+    });
 
-      if (finalResponse.usage) {
-        totalUsage = {
-          input_tokens:
-            ((totalUsage.input_tokens as number) ?? 0) + (finalResponse.usage.input_tokens ?? 0),
-          output_tokens:
-            ((totalUsage.output_tokens as number) ?? 0) + (finalResponse.usage.output_tokens ?? 0),
-        };
-      }
+    // Process streaming response
+    for await (const message of response) {
+      switch (message.type) {
+        case 'system':
+          // Session initialization - could store session_id for future use
+          if (message.subtype === 'init') {
+            // Session started
+          }
+          break;
 
-      const finalText = extractTextFromContent(finalResponse.content);
-      if (finalText) {
-        assistantMessage = finalText;
+        case 'assistant':
+          // Extract text content from assistant message
+          if (typeof message.message?.content === 'string') {
+            assistantMessage = message.message.content;
+          } else if (Array.isArray(message.message?.content)) {
+            const textBlocks = message.message.content.filter(
+              (block: { type: string }) => block.type === 'text'
+            );
+            assistantMessage = textBlocks
+              .map((block: { type: string; text?: string }) => block.text ?? '')
+              .join('\n')
+              .trim();
+          }
+          break;
+
+        case 'user':
+          // Tool results from user turns
+          if (message.message?.content && Array.isArray(message.message.content)) {
+            for (const block of message.message.content) {
+              if (block.type === 'tool_result') {
+                // Find the matching tool call and update its result
+                const toolCall = toolCalls.find(
+                  (tc) => tc.id === block.tool_use_id && tc.status === 'started'
+                );
+                if (toolCall) {
+                  toolCall.status = block.is_error ? 'error' : 'completed';
+                  // Extract text from content array
+                  if (Array.isArray(block.content)) {
+                    const textParts = block.content
+                      .filter((c: { type: string }) => c.type === 'text')
+                      .map((c: { type: string; text?: string }) => c.text ?? '');
+                    toolCall.result = textParts.join('\n');
+                  } else {
+                    toolCall.result = block.content;
+                  }
+                }
+              } else if (block.type === 'tool_use') {
+                // Track tool call start
+                toolCalls.push({
+                  id: block.id,
+                  tool: extractToolName(block.name),
+                  input: block.input,
+                  status: 'started',
+                  serverName: MCP_SERVER_NAME,
+                });
+              }
+            }
+          }
+          break;
+
+        case 'result':
+          // Final result with usage stats
+          if (message.subtype === 'success') {
+            if (message.result && typeof message.result === 'string') {
+              // Use result as final message if we don't have one
+              if (!assistantMessage) {
+                assistantMessage = message.result;
+              }
+            }
+            // Capture usage statistics
+            totalUsage = {
+              input_tokens: message.usage?.input_tokens ?? 0,
+              output_tokens: message.usage?.output_tokens ?? 0,
+              total_cost_usd: message.total_cost_usd ?? 0,
+              num_turns: message.num_turns ?? 0,
+              duration_ms: message.duration_ms ?? 0,
+            };
+          } else if (message.subtype === 'error_max_turns') {
+            // Max turns reached, still capture what we have
+            totalUsage = {
+              input_tokens: message.usage?.input_tokens ?? 0,
+              output_tokens: message.usage?.output_tokens ?? 0,
+              num_turns: message.num_turns ?? 0,
+            };
+          }
+          break;
+
+        default:
+          // Handle other message types as needed
+          break;
       }
-      break;
     }
+  } catch (error) {
+    console.error('Agent query failed:', error);
+    throw error;
   }
 
+  // Build updated conversation history
   const updatedHistory: AgentConversationMessage[] = [
     ...history,
     { role: 'user', content: params.message },
@@ -277,35 +280,4 @@ export async function runAgentChat(db: Pool, params: AgentChatParams): Promise<A
     history: updatedHistory,
     usage: totalUsage,
   };
-}
-
-function extractToolResultContent(result: string | { content?: unknown }): string {
-  if (typeof result === 'string') {
-    return result;
-  }
-
-  if (result && typeof result === 'object') {
-    if (result.content && Array.isArray(result.content)) {
-      const textParts: string[] = [];
-      for (const block of result.content) {
-        if (
-          block &&
-          typeof block === 'object' &&
-          block.type === 'text' &&
-          typeof block.text === 'string'
-        ) {
-          textParts.push(block.text);
-        }
-      }
-      const combined = textParts.join('\n').trim();
-      if (combined) {
-        return combined;
-      }
-    }
-
-    // Fallback to JSON stringify
-    return JSON.stringify(result, null, 2);
-  }
-
-  return String(result);
 }

--- a/apps/server/src/agent/tools.ts
+++ b/apps/server/src/agent/tools.ts
@@ -1262,8 +1262,7 @@ export function buildAgentMcpServer(db: Pool, context: ToolContext) {
         },
         async (args) => {
           try {
-            const dbPool = getPool();
-            const modelConfigService = getModelConfigService(dbPool);
+            const modelConfigService = getModelConfigService(db);
             const summaryConfig = await modelConfigService.getSummaryModelConfig();
 
             if (summaryConfig.provider === 'anthropic' && !process.env.ANTHROPIC_API_KEY) {

--- a/apps/server/src/agent/tools.ts
+++ b/apps/server/src/agent/tools.ts
@@ -1,3 +1,4 @@
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import Anthropic from '@anthropic-ai/sdk';
 import type { Tool } from '@anthropic-ai/sdk/resources/messages.js';
 import { createDocument, getDocument, getDocumentChunks, getPool } from '@synthesis/db';
@@ -37,6 +38,33 @@ type ToolExecutor = (input: unknown) => Promise<string>;
 function createToolResponse(message: string, payload?: unknown): string {
   const text = payload ? `${message}\n\n${JSON.stringify(payload, null, 2)}` : message;
   return text;
+}
+
+// =============================================================================
+// MCP Tool Result Format (for Claude Agent SDK)
+// =============================================================================
+
+/**
+ * MCP tool result format required by Claude Agent SDK
+ * Uses index signature for SDK compatibility
+ */
+export interface McpToolResult {
+  [key: string]: unknown;
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+}
+
+/**
+ * Create an MCP-compatible tool result
+ */
+function createMcpToolResult(text: string, isError = false): McpToolResult {
+  const result: McpToolResult = {
+    content: [{ type: 'text' as const, text }],
+  };
+  if (isError) {
+    result.isError = true;
+  }
+  return result;
 }
 
 type JsonSchema =
@@ -724,4 +752,573 @@ export function buildAgentTools(
   }
 
   return { tools, toolExecutors };
+}
+
+// =============================================================================
+// MCP Server Format (for Claude Agent SDK)
+// =============================================================================
+
+/** MCP server name used for tool namespacing */
+export const MCP_SERVER_NAME = 'synthesis-rag-tools';
+
+/** List of all tool names (for allowedTools configuration) */
+export const MCP_TOOL_NAMES = [
+  `mcp__${MCP_SERVER_NAME}__${SEARCH_TOOL_NAME}`,
+  `mcp__${MCP_SERVER_NAME}__${ADD_DOCUMENT_TOOL_NAME}`,
+  `mcp__${MCP_SERVER_NAME}__${FETCH_WEB_CONTENT_TOOL_NAME}`,
+  `mcp__${MCP_SERVER_NAME}__${LIST_COLLECTIONS_TOOL_NAME}`,
+  `mcp__${MCP_SERVER_NAME}__${LIST_DOCUMENTS_TOOL_NAME}`,
+  `mcp__${MCP_SERVER_NAME}__${GET_DOCUMENT_STATUS_TOOL_NAME}`,
+  `mcp__${MCP_SERVER_NAME}__${DELETE_DOCUMENT_TOOL_NAME}`,
+  `mcp__${MCP_SERVER_NAME}__${RESTART_INGEST_TOOL_NAME}`,
+  `mcp__${MCP_SERVER_NAME}__${SUMMARIZE_DOCUMENT_TOOL_NAME}`,
+] as const;
+
+/**
+ * Build an MCP server with all RAG tools for Claude Agent SDK.
+ *
+ * This is the new SDK-compatible format that replaces the manual agentic loop.
+ * Tools are automatically executed by the SDK when Claude requests them.
+ */
+export function buildAgentMcpServer(db: Pool, context: ToolContext) {
+  return createSdkMcpServer({
+    name: MCP_SERVER_NAME,
+    version: '1.0.0',
+    tools: [
+      // search_rag
+      tool(
+        SEARCH_TOOL_NAME,
+        'Search the RAG knowledge base for relevant information and return matching chunks with citations.',
+        {
+          query: z.string().min(1).describe('Search query'),
+          collection_id: z
+            .string()
+            .uuid()
+            .optional()
+            .describe('Collection ID (defaults to active collection)'),
+          top_k: z
+            .number()
+            .int()
+            .min(1)
+            .max(50)
+            .optional()
+            .describe('Number of results (default: 5)'),
+          min_similarity: z
+            .number()
+            .min(0)
+            .max(1)
+            .optional()
+            .describe('Minimum similarity threshold (default: 0.5)'),
+          search_mode: z.enum(['vector', 'hybrid']).optional().describe('Search mode'),
+        },
+        async (args) => {
+          try {
+            const searchResult = await smartSearch(db, {
+              query: args.query,
+              collectionId: args.collection_id ?? context.collectionId,
+              topK: args.top_k ?? 5,
+              minSimilarity: args.min_similarity ?? 0.5,
+              mode: args.search_mode,
+            });
+            const payload = {
+              query: searchResult.query,
+              results: searchResult.results,
+              total_results: searchResult.totalResults,
+              search_time_ms: searchResult.searchTimeMs,
+              metadata: searchResult.metadata,
+            };
+            return createMcpToolResult(
+              createToolResponse(
+                `Search (${searchResult.metadata.searchMode}) completed for "${payload.query}". Returning ${payload.total_results} result(s).`,
+                payload
+              )
+            );
+          } catch (error) {
+            return createMcpToolResult(
+              `Error searching: ${error instanceof Error ? error.message : 'Unknown error'}`,
+              true
+            );
+          }
+        }
+      ),
+
+      // add_document
+      tool(
+        ADD_DOCUMENT_TOOL_NAME,
+        'Add a document to the RAG system from a LOCAL FILE PATH or RAW FILE URL (PDFs, markdown, code files). For HTML web pages, use fetch_web_content instead.',
+        {
+          source: z.string().min(1).describe('File path or URL'),
+          collection_id: z.string().uuid().optional().describe('Collection ID'),
+          title: z.string().min(1).optional().describe('Document title'),
+          metadata: z.record(z.any()).optional().describe('Additional metadata'),
+        },
+        async (args) => {
+          try {
+            const collectionId = args.collection_id ?? context.collectionId;
+            const source = args.source.trim();
+            const metadata = args.metadata ?? {};
+            const remote = isUrl(source);
+
+            // For remote URLs, check if it's an HTML page
+            if (remote) {
+              const url = new URL(source);
+              const pathname = url.pathname.toLowerCase();
+              const isRawFile =
+                pathname.endsWith('.pdf') ||
+                pathname.endsWith('.md') ||
+                pathname.endsWith('.txt') ||
+                pathname.endsWith('.json') ||
+                pathname.endsWith('.yaml') ||
+                pathname.endsWith('.yml') ||
+                pathname.endsWith('.xml') ||
+                pathname.endsWith('.csv') ||
+                pathname.endsWith('.dart') ||
+                pathname.endsWith('.ts') ||
+                pathname.endsWith('.tsx') ||
+                pathname.endsWith('.js') ||
+                pathname.endsWith('.jsx') ||
+                pathname.endsWith('.py') ||
+                pathname.endsWith('.go') ||
+                pathname.endsWith('.rs') ||
+                pathname.endsWith('.java') ||
+                pathname.endsWith('.kt') ||
+                pathname.endsWith('.swift') ||
+                url.hostname === 'raw.githubusercontent.com' ||
+                url.hostname.includes('raw.') ||
+                url.pathname.includes('/raw/');
+
+              if (!isRawFile) {
+                const result = await fetchWebContent(db, {
+                  url: source,
+                  collectionId,
+                  mode: 'single',
+                  titlePrefix: args.title,
+                });
+                return createMcpToolResult(
+                  createToolResponse(
+                    `Detected web page URL. Used fetch_web_content for proper HTML extraction. Fetched and queued ${result.processed.length} page(s) for ingestion.`,
+                    result.processed
+                  )
+                );
+              }
+            }
+
+            const download = remote
+              ? await downloadRemoteFile(source)
+              : await readLocalFile(source);
+            const remoteDownload = remote ? (download as RemoteDownloadResult) : null;
+            const referenceName = remoteDownload?.fileName ?? source;
+            const contentType = inferContentType(
+              referenceName,
+              remoteDownload?.contentType ?? download.contentType
+            );
+            const extension = inferExtension(contentType, referenceName);
+            const title = args.title?.trim()?.length
+              ? args.title.trim()
+              : inferTitle(referenceName);
+
+            const document = await createDocument({
+              collection_id: collectionId,
+              title,
+              file_path: undefined,
+              content_type: contentType,
+              file_size: download.buffer.length,
+              source_url: remote ? source : undefined,
+            });
+
+            if (Object.keys(metadata).length > 0) {
+              await db.query('UPDATE documents SET metadata = $1 WHERE id = $2', [
+                metadata,
+                document.id,
+              ]);
+            }
+
+            const filePath = await writeDocumentFile(
+              collectionId,
+              document.id,
+              extension,
+              download.buffer
+            );
+            await updateDocumentStatusSafe(db, document.id, 'pending', undefined, filePath);
+
+            ingestDocument(document.id).catch((error: unknown) => {
+              console.error(`Ingestion failed for ${document.id}`, error);
+            });
+
+            return createMcpToolResult(
+              createToolResponse('Document queued for ingestion.', {
+                doc_id: document.id,
+                title,
+                collection_id: collectionId,
+                content_type: contentType,
+                file_path: filePath,
+                metadata,
+              })
+            );
+          } catch (error) {
+            return createMcpToolResult(
+              `Error adding document: ${error instanceof Error ? error.message : 'Unknown error'}`,
+              true
+            );
+          }
+        }
+      ),
+
+      // fetch_web_content
+      tool(
+        FETCH_WEB_CONTENT_TOOL_NAME,
+        'Fetch web content (single page or crawl) and ingest it into the active collection.',
+        {
+          url: z.string().url().describe('Web page URL'),
+          collection_id: z.string().uuid().optional().describe('Collection ID'),
+          mode: z.enum(['single', 'crawl']).optional().describe('Fetch mode (default: single)'),
+          max_pages: z
+            .number()
+            .int()
+            .min(1)
+            .max(200)
+            .optional()
+            .describe('Max pages to crawl (default: 25)'),
+          title_prefix: z.string().min(1).optional().describe('Title prefix for documents'),
+        },
+        async (args) => {
+          try {
+            const collectionId = args.collection_id ?? context.collectionId;
+            const result = await fetchWebContent(db, {
+              url: args.url,
+              collectionId,
+              mode: args.mode ?? 'single',
+              maxPages: args.max_pages ?? 25,
+              titlePrefix: args.title_prefix,
+            });
+            return createMcpToolResult(
+              createToolResponse(
+                `Fetched and queued ${result.processed.length} page(s) for ingestion.`,
+                result.processed
+              )
+            );
+          } catch (error) {
+            return createMcpToolResult(
+              `Failed to fetch content from ${args.url}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+              true
+            );
+          }
+        }
+      ),
+
+      // list_collections
+      tool(
+        LIST_COLLECTIONS_TOOL_NAME,
+        'List available collections with document counts.',
+        {},
+        async () => {
+          try {
+            const { rows } = await db.query<{
+              id: string;
+              name: string;
+              description: string | null;
+              doc_count: string;
+              created_at: Date;
+            }>(`
+              SELECT c.id, c.name, c.description, COUNT(d.id)::text AS doc_count, c.created_at
+              FROM collections c
+              LEFT JOIN documents d ON d.collection_id = c.id
+              GROUP BY c.id
+              ORDER BY c.created_at DESC
+            `);
+            const collections = rows.map((row) => ({
+              id: row.id,
+              name: row.name,
+              description: row.description,
+              doc_count: Number(row.doc_count),
+              created_at: row.created_at,
+            }));
+            return createMcpToolResult(
+              createToolResponse('Collections retrieved.', { collections })
+            );
+          } catch (error) {
+            return createMcpToolResult(
+              `Error listing collections: ${error instanceof Error ? error.message : 'Unknown error'}`,
+              true
+            );
+          }
+        }
+      ),
+
+      // list_documents
+      tool(
+        LIST_DOCUMENTS_TOOL_NAME,
+        'List documents in a collection with status information.',
+        {
+          collection_id: z.string().uuid().optional().describe('Collection ID'),
+          status: z
+            .enum(['pending', 'extracting', 'chunking', 'embedding', 'complete', 'error', 'all'])
+            .optional()
+            .describe('Filter by status (default: all)'),
+          limit: z.number().int().min(1).max(200).optional().describe('Max results (default: 50)'),
+        },
+        async (args) => {
+          try {
+            const collectionId = args.collection_id ?? context.collectionId;
+            const params: Array<string | number> = [collectionId];
+            let paramIndex = 2;
+            let statusFilter = '';
+            if (args.status && args.status !== 'all') {
+              statusFilter = `AND d.status = $${paramIndex++}`;
+              params.push(args.status);
+            }
+            params.push(args.limit ?? 50);
+
+            const { rows } = await db.query<{
+              id: string;
+              title: string;
+              status: string;
+              file_size: number | null;
+              source_url: string | null;
+              created_at: Date;
+              updated_at: Date;
+              chunk_count: string;
+              token_count: string | null;
+            }>(
+              `SELECT d.id, d.title, d.status, d.file_size, d.source_url, d.created_at, d.updated_at,
+                COUNT(ch.id)::text AS chunk_count, SUM(ch.token_count)::text AS token_count
+               FROM documents d
+               LEFT JOIN chunks ch ON ch.doc_id = d.id
+               WHERE d.collection_id = $1 ${statusFilter}
+               GROUP BY d.id
+               ORDER BY d.created_at DESC
+               LIMIT $${paramIndex}`,
+              params
+            );
+
+            const documents = rows.map((row) => ({
+              id: row.id,
+              title: row.title,
+              status: row.status,
+              file_size: row.file_size,
+              source_url: row.source_url,
+              created_at: row.created_at,
+              updated_at: row.updated_at,
+              chunk_count: Number(row.chunk_count),
+              token_count: row.token_count ? Number(row.token_count) : null,
+            }));
+            return createMcpToolResult(
+              createToolResponse(`Retrieved ${documents.length} document(s).`, { documents })
+            );
+          } catch (error) {
+            return createMcpToolResult(
+              `Error listing documents: ${error instanceof Error ? error.message : 'Unknown error'}`,
+              true
+            );
+          }
+        }
+      ),
+
+      // get_document_status
+      tool(
+        GET_DOCUMENT_STATUS_TOOL_NAME,
+        'Check the processing status of a document.',
+        {
+          doc_id: z.string().uuid().describe('Document ID'),
+        },
+        async (args) => {
+          try {
+            const { rows } = await db.query<{
+              id: string;
+              title: string;
+              status: string;
+              error_message: string | null;
+              created_at: Date;
+              processed_at: Date | null;
+              file_path: string | null;
+              chunk_count: string;
+              total_tokens: string | null;
+            }>(
+              `SELECT d.id, d.title, d.status, d.error_message, d.created_at, d.processed_at, d.file_path,
+                COUNT(ch.id)::text AS chunk_count, SUM(ch.token_count)::text AS total_tokens
+               FROM documents d
+               LEFT JOIN chunks ch ON ch.doc_id = d.id
+               WHERE d.id = $1
+               GROUP BY d.id`,
+              [args.doc_id]
+            );
+
+            if (rows.length === 0) {
+              return createMcpToolResult(createToolResponse(`Document ${args.doc_id} not found.`));
+            }
+
+            const doc = rows[0];
+            const payload = {
+              doc_id: doc.id,
+              title: doc.title,
+              status: doc.status,
+              error: doc.error_message,
+              created_at: doc.created_at,
+              processed_at: doc.processed_at,
+              chunk_count: Number(doc.chunk_count),
+              total_tokens: doc.total_tokens ? Number(doc.total_tokens) : null,
+              file_path: doc.file_path,
+            };
+            return createMcpToolResult(
+              createToolResponse(`Status retrieved for document ${doc.title}.`, payload)
+            );
+          } catch (error) {
+            return createMcpToolResult(
+              `Error getting document status: ${error instanceof Error ? error.message : 'Unknown error'}`,
+              true
+            );
+          }
+        }
+      ),
+
+      // delete_document
+      tool(
+        DELETE_DOCUMENT_TOOL_NAME,
+        'Delete a document and all associated chunks (requires confirm=true).',
+        {
+          doc_id: z.string().uuid().describe('Document ID'),
+          confirm: z.boolean().optional().describe('Confirm deletion'),
+        },
+        async (args) => {
+          try {
+            if (!args.confirm) {
+              return createMcpToolResult(
+                createToolResponse(
+                  'Deletion not confirmed. Set confirm=true to permanently remove the document.'
+                )
+              );
+            }
+            const result = await deleteDocumentById(db, { docId: args.doc_id });
+            return createMcpToolResult(
+              createToolResponse(`Document ${result.title} deleted.`, {
+                doc_id: result.docId,
+                title: result.title,
+              })
+            );
+          } catch (error) {
+            return createMcpToolResult(
+              error instanceof Error ? error.message : 'Failed to delete document.',
+              true
+            );
+          }
+        }
+      ),
+
+      // restart_ingest
+      tool(
+        RESTART_INGEST_TOOL_NAME,
+        'Retry ingestion for a document that previously failed or is stuck.',
+        {
+          doc_id: z.string().uuid().describe('Document ID'),
+        },
+        async (args) => {
+          try {
+            const document = await getDocument(args.doc_id);
+            if (!document) {
+              return createMcpToolResult(createToolResponse(`Document ${args.doc_id} not found.`));
+            }
+            if (!document.file_path) {
+              return createMcpToolResult(
+                createToolResponse(`Document ${document.id} has no stored file to ingest.`)
+              );
+            }
+
+            await db.query(
+              `UPDATE documents
+               SET status = 'pending', error_message = NULL, processed_at = NULL, updated_at = NOW()
+               WHERE id = $1`,
+              [document.id]
+            );
+
+            ingestDocument(document.id).catch((error: unknown) => {
+              console.error(`Re-ingestion failed for ${document.id}`, error);
+            });
+
+            return createMcpToolResult(
+              createToolResponse(`Re-ingestion started for document ${document.title}.`)
+            );
+          } catch (error) {
+            return createMcpToolResult(
+              `Error restarting ingest: ${error instanceof Error ? error.message : 'Unknown error'}`,
+              true
+            );
+          }
+        }
+      ),
+
+      // summarize_document
+      tool(
+        SUMMARIZE_DOCUMENT_TOOL_NAME,
+        'Summarize a document using Claude based on its stored chunks.',
+        {
+          doc_id: z.string().uuid().describe('Document ID'),
+          max_chunks: z
+            .number()
+            .int()
+            .min(1)
+            .max(25)
+            .optional()
+            .describe('Max chunks to include (default: 10)'),
+        },
+        async (args) => {
+          try {
+            const dbPool = getPool();
+            const modelConfigService = getModelConfigService(dbPool);
+            const summaryConfig = await modelConfigService.getSummaryModelConfig();
+
+            if (summaryConfig.provider === 'anthropic' && !process.env.ANTHROPIC_API_KEY) {
+              return createMcpToolResult(
+                createToolResponse(
+                  'Summarization unavailable: ANTHROPIC_API_KEY environment variable is not set.'
+                )
+              );
+            }
+
+            const document = await getDocument(args.doc_id);
+            if (!document) {
+              return createMcpToolResult(createToolResponse(`Document ${args.doc_id} not found.`));
+            }
+
+            const chunks = await getDocumentChunks(document.id);
+            if (chunks.length === 0) {
+              return createMcpToolResult(
+                createToolResponse(`Document ${document.title} has no chunks to summarize.`)
+              );
+            }
+
+            const selectedChunks = chunks.slice(0, args.max_chunks ?? 10);
+            const combinedText = selectedChunks.map((chunk) => chunk.text).join('\n\n');
+
+            const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+            const response = await client.messages.create({
+              model: summaryConfig.model,
+              max_tokens: 512,
+              system:
+                'You are a documentation assistant that summarizes technical documents concisely with key points and citations when possible.',
+              messages: [
+                {
+                  role: 'user',
+                  content: `Summarize the following document titled "${document.title}". Highlight the main points and include section references if provided.\n\n${combinedText}`,
+                },
+              ],
+            });
+
+            const summary = extractTextContent(response);
+            return createMcpToolResult(
+              createToolResponse(`Summary generated for document ${document.title}.`, {
+                doc_id: document.id,
+                title: document.title,
+                summary,
+              })
+            );
+          } catch (error) {
+            return createMcpToolResult(
+              `Error summarizing document: ${error instanceof Error ? error.message : 'Unknown error'}`,
+              true
+            );
+          }
+        }
+      ),
+    ],
+  });
 }

--- a/apps/server/src/services/chat-providers/adapters.ts
+++ b/apps/server/src/services/chat-providers/adapters.ts
@@ -1,0 +1,368 @@
+/**
+ * Tool Format Adapters
+ *
+ * Phase 16A: Convert between normalized ChatTool format and provider-specific formats.
+ * Each provider has slightly different tool/function calling schemas.
+ */
+
+import type { ChatContentBlock, ChatMessage, ChatTool, ChatToolCall } from './types.js';
+
+// =============================================================================
+// Anthropic Adapters
+// =============================================================================
+
+/**
+ * Anthropic tool format
+ */
+export interface AnthropicTool {
+  name: string;
+  description: string;
+  input_schema: {
+    type: 'object';
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+}
+
+/**
+ * Anthropic tool_use block from response
+ */
+export interface AnthropicToolUseBlock {
+  type: 'tool_use';
+  id: string;
+  name: string;
+  input: unknown;
+}
+
+/**
+ * Anthropic message format
+ */
+export interface AnthropicMessage {
+  role: 'user' | 'assistant';
+  content: string | AnthropicContentBlock[];
+}
+
+export type AnthropicContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'tool_use'; id: string; name: string; input: unknown }
+  | { type: 'tool_result'; tool_use_id: string; content: string; is_error?: boolean };
+
+/**
+ * Convert normalized tool to Anthropic format
+ */
+export function toAnthropicTool(tool: ChatTool): AnthropicTool {
+  return {
+    name: tool.name,
+    description: tool.description,
+    input_schema: tool.inputSchema,
+  };
+}
+
+/**
+ * Convert Anthropic tool_use response to normalized format
+ */
+export function fromAnthropicToolUse(block: AnthropicToolUseBlock): ChatToolCall {
+  return {
+    id: block.id,
+    name: block.name,
+    input: block.input,
+  };
+}
+
+/**
+ * Convert normalized messages to Anthropic format
+ * Note: System messages are handled separately in Anthropic API
+ */
+export function toAnthropicMessages(messages: ChatMessage[]): AnthropicMessage[] {
+  return messages
+    .filter((msg) => msg.role !== 'system') // System handled separately
+    .map((msg) => ({
+      role: msg.role as 'user' | 'assistant',
+      content: typeof msg.content === 'string' ? msg.content : toAnthropicContent(msg.content),
+    }));
+}
+
+/**
+ * Convert normalized content blocks to Anthropic format
+ */
+function toAnthropicContent(blocks: ChatContentBlock[]): AnthropicContentBlock[] {
+  return blocks.map((block) => {
+    switch (block.type) {
+      case 'text':
+        return { type: 'text' as const, text: block.text ?? '' };
+      case 'tool_use':
+        return {
+          type: 'tool_use' as const,
+          id: block.id ?? '',
+          name: block.name ?? '',
+          input: block.input,
+        };
+      case 'tool_result':
+        return {
+          type: 'tool_result' as const,
+          tool_use_id: block.toolUseId ?? '',
+          content: block.content ?? '',
+          is_error: block.isError,
+        };
+      default:
+        return { type: 'text' as const, text: '' };
+    }
+  });
+}
+
+// =============================================================================
+// OpenAI Adapters
+// =============================================================================
+
+/**
+ * OpenAI tool format (function calling)
+ */
+export interface OpenAITool {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: {
+      type: 'object';
+      properties: Record<string, unknown>;
+      required?: string[];
+    };
+  };
+}
+
+/**
+ * OpenAI tool call from response
+ */
+export interface OpenAIToolCall {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string; // JSON string
+  };
+}
+
+/**
+ * OpenAI message format
+ */
+export interface OpenAIMessage {
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  content: string | null;
+  tool_calls?: OpenAIToolCall[];
+  tool_call_id?: string;
+}
+
+/**
+ * Convert normalized tool to OpenAI function format
+ */
+export function toOpenAITool(tool: ChatTool): OpenAITool {
+  return {
+    type: 'function',
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.inputSchema,
+    },
+  };
+}
+
+/**
+ * Convert OpenAI tool_call to normalized format
+ */
+export function fromOpenAIToolCall(call: OpenAIToolCall): ChatToolCall {
+  let input: unknown;
+  try {
+    input = JSON.parse(call.function.arguments);
+  } catch {
+    input = call.function.arguments;
+  }
+
+  return {
+    id: call.id,
+    name: call.function.name,
+    input,
+  };
+}
+
+/**
+ * Convert normalized messages to OpenAI format
+ */
+export function toOpenAIMessages(messages: ChatMessage[]): OpenAIMessage[] {
+  return messages.flatMap((msg) => {
+    if (typeof msg.content === 'string') {
+      return [
+        {
+          role: msg.role,
+          content: msg.content ?? '',
+        },
+      ];
+    }
+
+    // Handle complex content (tool results, etc.)
+    return toOpenAIMessageWithContent(msg);
+  });
+}
+
+/**
+ * Convert message with content blocks to OpenAI format
+ *
+ * Note: This may expand a single normalized message into
+ * multiple OpenAI messages (e.g. one per tool_result block).
+ */
+function toOpenAIMessageWithContent(msg: ChatMessage): OpenAIMessage[] {
+  const blocks = msg.content as ChatContentBlock[];
+
+  // Check for tool results
+  const toolResults = blocks.filter((b) => b.type === 'tool_result' && b.toolUseId);
+  if (toolResults.length > 0) {
+    return toolResults.map((tr) => ({
+      role: 'tool' as const,
+      content: tr.content ?? '',
+      tool_call_id: tr.toolUseId as string,
+    }));
+  }
+
+  // Check for tool calls (assistant message)
+  const toolCalls = blocks.filter((b) => b.type === 'tool_use');
+  if (toolCalls.length > 0) {
+    return [
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: toolCalls.map((tc) => ({
+          id: tc.id ?? '',
+          type: 'function' as const,
+          function: {
+            name: tc.name ?? '',
+            arguments: JSON.stringify(tc.input ?? {}),
+          },
+        })),
+      },
+    ];
+  }
+
+  // Default: join text blocks
+  const text = blocks
+    .filter((b) => b.type === 'text')
+    .map((b) => b.text ?? '')
+    .join('\n');
+
+  return [
+    {
+      role: msg.role,
+      content: text,
+    },
+  ];
+}
+
+// =============================================================================
+// Google AI Adapters (Gemini)
+// =============================================================================
+
+/**
+ * Google functionDeclaration format
+ */
+export interface GoogleFunctionDeclaration {
+  name: string;
+  description: string;
+  parameters: {
+    type: 'object';
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+}
+
+/**
+ * Google function call from response
+ */
+export interface GoogleFunctionCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+/**
+ * Convert normalized tool to Google functionDeclaration
+ */
+export function toGoogleTool(tool: ChatTool): GoogleFunctionDeclaration {
+  return {
+    name: tool.name,
+    description: tool.description,
+    parameters: {
+      type: 'object',
+      properties: tool.inputSchema.properties,
+      required: tool.inputSchema.required,
+    },
+  };
+}
+
+/**
+ * Convert Google function call to normalized format
+ * Note: Google doesn't provide an ID, so we generate one
+ */
+export function fromGoogleFunctionCall(call: GoogleFunctionCall, index: number): ChatToolCall {
+  return {
+    id: `google-${index}-${Date.now()}`,
+    name: call.name,
+    input: call.args,
+  };
+}
+
+// =============================================================================
+// Stop Reason Mapping
+// =============================================================================
+
+/**
+ * Map Anthropic stop reason to normalized format
+ */
+export function mapAnthropicStopReason(
+  reason: string | null
+): 'end_turn' | 'tool_use' | 'max_tokens' | 'stop_sequence' {
+  switch (reason) {
+    case 'tool_use':
+      return 'tool_use';
+    case 'max_tokens':
+      return 'max_tokens';
+    case 'stop_sequence':
+      return 'stop_sequence';
+    default:
+      return 'end_turn';
+  }
+}
+
+/**
+ * Map OpenAI finish reason to normalized format
+ */
+export function mapOpenAIStopReason(
+  reason: string | null | undefined
+): 'end_turn' | 'tool_use' | 'max_tokens' | 'stop_sequence' {
+  switch (reason) {
+    case 'tool_calls':
+      return 'tool_use';
+    case 'length':
+      return 'max_tokens';
+    case 'stop':
+      return 'stop_sequence';
+    default:
+      return 'end_turn';
+  }
+}
+
+/**
+ * Map Google finish reason to normalized format
+ */
+export function mapGoogleStopReason(
+  reason: string | undefined
+): 'end_turn' | 'tool_use' | 'max_tokens' | 'stop_sequence' {
+  switch (reason) {
+    case 'STOP':
+      return 'end_turn';
+    case 'MAX_TOKENS':
+      return 'max_tokens';
+    case 'SAFETY':
+    case 'RECITATION':
+    case 'OTHER':
+      return 'end_turn';
+    default:
+      return 'end_turn';
+  }
+}

--- a/apps/server/src/services/chat-providers/index.ts
+++ b/apps/server/src/services/chat-providers/index.ts
@@ -1,0 +1,213 @@
+/**
+ * Chat Provider Registry
+ *
+ * Phase 16A: Registry pattern for multi-provider chat support.
+ * Follows singleton pattern from model-config-service.ts.
+ */
+
+import { PROVIDER_INFO } from '@synthesis/shared';
+import type { Pool } from 'pg';
+import { getApiKeyService } from '../api-key-service.js';
+import { getModelConfigService } from '../model-config-service.js';
+import type { ChatProvider, ChatProviderFactory, ChatProviderType } from './types.js';
+
+// =============================================================================
+// Provider Registry
+// =============================================================================
+
+/** Provider factory registry */
+const providerFactories = new Map<ChatProviderType, ChatProviderFactory>();
+
+/** Cached provider instances (lazy initialization) */
+const providerInstances = new Map<ChatProviderType, ChatProvider>();
+
+/**
+ * Register a chat provider factory
+ * Called at module load time by provider implementations
+ */
+export function registerChatProvider(name: ChatProviderType, factory: ChatProviderFactory): void {
+  providerFactories.set(name, factory);
+}
+
+/**
+ * Get a chat provider by name (cached)
+ * @throws Error if provider not registered
+ */
+export function getChatProvider(name: ChatProviderType): ChatProvider {
+  // Check cache first
+  let provider = providerInstances.get(name);
+  if (provider) {
+    return provider;
+  }
+
+  // Get factory
+  const factory = providerFactories.get(name);
+  if (!factory) {
+    throw new Error(
+      `Unknown chat provider: ${name}. ` +
+        `Available providers: ${Array.from(providerFactories.keys()).join(', ')}`
+    );
+  }
+
+  // Create and cache instance
+  provider = factory();
+  providerInstances.set(name, provider);
+  return provider;
+}
+
+/**
+ * Get the configured chat provider from ModelConfigService
+ * Uses the 'chat' feature configuration
+ */
+export async function getConfiguredChatProvider(db: Pool): Promise<ChatProvider> {
+  const configService = getModelConfigService(db);
+  const config = await configService.getChatModelConfig();
+
+  const providerName = config.provider as ChatProviderType;
+  const provider = getChatProvider(providerName);
+
+  // Validate provider is configured (has API key if required)
+  const isConfigured = await provider.isConfigured();
+  if (!isConfigured) {
+    throw new Error(
+      `Chat provider '${config.provider}' is not configured. ` +
+        'Please set the API key in Settings > API Keys.'
+    );
+  }
+
+  return provider;
+}
+
+/**
+ * Get list of registered provider names
+ */
+export function getRegisteredProviders(): ChatProviderType[] {
+  return Array.from(providerFactories.keys());
+}
+
+/**
+ * Get list of configured (ready to use) providers
+ */
+export async function getAvailableChatProviders(): Promise<ChatProviderType[]> {
+  const available: ChatProviderType[] = [];
+
+  for (const name of providerFactories.keys()) {
+    try {
+      const provider = getChatProvider(name);
+      const isConfigured = await provider.isConfigured();
+      if (isConfigured) {
+        available.push(name);
+      }
+    } catch {
+      // Provider failed to initialize, skip
+    }
+  }
+
+  return available;
+}
+
+/**
+ * Check if a provider supports tools
+ */
+export function providerSupportsTools(name: ChatProviderType): boolean {
+  try {
+    const provider = getChatProvider(name);
+    return provider.capabilities.supportsTools;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if a provider supports streaming
+ */
+export function providerSupportsStreaming(name: ChatProviderType): boolean {
+  try {
+    const provider = getChatProvider(name);
+    return provider.capabilities.supportsStreaming;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Reset provider cache (for testing)
+ */
+export function resetChatProviders(): void {
+  providerInstances.clear();
+}
+
+/**
+ * Clear all registrations and cache (for testing)
+ */
+export function resetChatProviderRegistry(): void {
+  providerFactories.clear();
+  providerInstances.clear();
+}
+
+// =============================================================================
+// API Key Resolution Helper
+// =============================================================================
+
+/**
+ * Get API key for a provider
+ * Checks database (ApiKeyService) first, then environment variables
+ *
+ * @param db Database pool for ApiKeyService
+ * @param provider Provider name
+ * @returns API key or null if not configured
+ */
+export async function getProviderApiKey(db: Pool, provider: string): Promise<string | null> {
+  // Try database first (via ApiKeyService)
+  try {
+    const apiKeyService = getApiKeyService(db);
+    const dbKey = await apiKeyService.getKey(provider);
+    if (dbKey) {
+      return dbKey;
+    }
+  } catch {
+    // ApiKeyService may fail if table doesn't exist yet
+  }
+
+  // Fall back to environment variable
+  const providerInfo = PROVIDER_INFO[provider];
+  if (providerInfo?.apiKeyEnvVar) {
+    const envKey = process.env[providerInfo.apiKeyEnvVar];
+    if (envKey && envKey.trim().length > 0) {
+      return envKey;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Check if a provider's API key is configured
+ * Checks database first, then environment variables
+ */
+export async function isProviderApiKeyConfigured(db: Pool, provider: string): Promise<boolean> {
+  const key = await getProviderApiKey(db, provider);
+  return key !== null;
+}
+
+// =============================================================================
+// Re-exports
+// =============================================================================
+
+export * from './types.js';
+export * from './adapters.js';
+
+// =============================================================================
+// Provider Registration
+// =============================================================================
+
+// Note: Provider implementations will be added in Phase 16B
+// They will register themselves when imported:
+//
+// import { createAnthropicProvider } from './anthropic.js';
+// import { createOpenAIProvider } from './openai.js';
+// import { createOllamaProvider } from './ollama.js';
+//
+// registerChatProvider('anthropic', createAnthropicProvider);
+// registerChatProvider('openai', createOpenAIProvider);
+// registerChatProvider('ollama', createOllamaProvider);

--- a/apps/server/src/services/chat-providers/types.ts
+++ b/apps/server/src/services/chat-providers/types.ts
@@ -1,0 +1,203 @@
+/**
+ * Chat Provider Types
+ *
+ * Phase 16A: Provider-agnostic interfaces for multi-provider chat support.
+ * These types normalize the differences between Anthropic, OpenAI, Google, etc.
+ */
+
+import type { LLMProvider } from '@synthesis/shared';
+
+/**
+ * Extended provider type including P2 providers (Zhipu, Moonshot)
+ */
+export type ChatProviderType = LLMProvider;
+
+/**
+ * Provider capability flags
+ */
+export interface ProviderCapabilities {
+  /** Supports tool/function calling */
+  supportsTools: boolean;
+  /** Supports streaming responses */
+  supportsStreaming: boolean;
+  /** Supports vision/image input */
+  supportsVision: boolean;
+  /** Maximum context window (tokens) */
+  maxContextTokens: number;
+}
+
+/**
+ * Content block types for complex message content
+ */
+export interface ChatContentBlock {
+  type: 'text' | 'image' | 'tool_use' | 'tool_result';
+  /** For text blocks */
+  text?: string;
+  /** For image blocks */
+  source?: {
+    type: 'base64' | 'url';
+    mediaType?: string;
+    data?: string;
+    url?: string;
+  };
+  /** For tool_use blocks */
+  id?: string;
+  name?: string;
+  input?: unknown;
+  /** For tool_result blocks */
+  toolUseId?: string;
+  content?: string;
+  isError?: boolean;
+}
+
+/**
+ * Normalized message format (provider-agnostic)
+ */
+export interface ChatMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string | ChatContentBlock[];
+}
+
+/**
+ * Normalized tool definition (provider-agnostic)
+ * Based on JSON Schema format that all providers support
+ */
+export interface ChatTool {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: 'object';
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+}
+
+/**
+ * Parameters for chat request
+ */
+export interface ChatParams {
+  /** Conversation messages */
+  messages: ChatMessage[];
+  /** Model identifier (provider-specific) */
+  model: string;
+  /** System prompt (handled differently by each provider) */
+  systemPrompt?: string;
+  /** Tools available to the model */
+  tools?: ChatTool[];
+  /** Maximum tokens to generate */
+  maxTokens?: number;
+  /** Sampling temperature (0-1) */
+  temperature?: number;
+  /** Stop sequences */
+  stopSequences?: string[];
+}
+
+/**
+ * Normalized tool call from model response
+ */
+export interface ChatToolCall {
+  /** Unique identifier for this tool call */
+  id: string;
+  /** Tool name */
+  name: string;
+  /** Tool input arguments */
+  input: unknown;
+}
+
+/**
+ * Token usage tracking
+ */
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+/**
+ * Stop reason for model response
+ */
+export type ChatStopReason = 'end_turn' | 'tool_use' | 'max_tokens' | 'stop_sequence';
+
+/**
+ * Normalized chat response (non-streaming)
+ */
+export interface ChatResponse {
+  /** Text content from response */
+  content: string;
+  /** Tool calls requested by model */
+  toolCalls: ChatToolCall[];
+  /** Why the model stopped generating */
+  stopReason: ChatStopReason;
+  /** Token usage */
+  usage: TokenUsage;
+  /** Model that actually responded */
+  model: string;
+  /** Provider that handled request */
+  provider: ChatProviderType;
+}
+
+/**
+ * Streaming chunk types for real-time response
+ */
+export type ChatStreamChunkType =
+  | 'text'
+  | 'tool_start'
+  | 'tool_delta'
+  | 'tool_end'
+  | 'usage'
+  | 'done';
+
+/**
+ * Streaming chunk (for Phase 16C SSE streaming)
+ */
+export interface ChatStreamChunk {
+  type: ChatStreamChunkType;
+  /** For text chunks - the token/text fragment */
+  text?: string;
+  /** For tool chunks - partial tool call data */
+  toolCall?: Partial<ChatToolCall>;
+  /** For usage/done chunks - final token counts */
+  usage?: TokenUsage;
+  /** For done chunks - the stop reason */
+  stopReason?: ChatStopReason;
+}
+
+/**
+ * Chat provider interface
+ *
+ * Implementations must normalize their SDK's response format
+ * to these common types.
+ */
+export interface ChatProvider {
+  /** Provider identifier */
+  readonly name: ChatProviderType;
+
+  /** Provider capabilities */
+  readonly capabilities: ProviderCapabilities;
+
+  /**
+   * Send chat message (non-streaming)
+   * @param params Chat parameters
+   * @returns Normalized response
+   */
+  chat(params: ChatParams): Promise<ChatResponse>;
+
+  /**
+   * Send chat message (streaming) - Phase 16C
+   * Returns async generator for token-by-token streaming
+   * @param params Chat parameters
+   * @returns Async generator of stream chunks
+   */
+  streamChat?(params: ChatParams): AsyncGenerator<ChatStreamChunk, void, unknown>;
+
+  /**
+   * Check if provider is configured (has API key if required)
+   * Async to support database lookup via ApiKeyService
+   */
+  isConfigured(): Promise<boolean>;
+}
+
+/**
+ * Factory function signature for creating providers
+ */
+export type ChatProviderFactory = () => ChatProvider;

--- a/apps/server/src/services/model-config-service.ts
+++ b/apps/server/src/services/model-config-service.ts
@@ -45,7 +45,7 @@ export function isValidFeature(feature: string): feature is ModelFeature {
 export function isValidProviderForFeature(feature: ModelFeature, provider: string): boolean {
   // LLM features
   if (['chat', 'summary', 'ocr', 'contradiction'].includes(feature)) {
-    return ['anthropic', 'openai', 'ollama', 'google'].includes(provider);
+    return ['anthropic', 'openai', 'ollama', 'google', 'zhipu', 'moonshot'].includes(provider);
   }
 
   // Embedding features

--- a/docs/phases/phase-16/00_PHASE_16_OVERVIEW.md
+++ b/docs/phases/phase-16/00_PHASE_16_OVERVIEW.md
@@ -387,3 +387,27 @@ feat(phase-16X): short description
 - Current agent code: `apps/server/src/agent/agent.ts`
 - Model config service: `apps/server/src/services/model-config-service.ts`
 - Settings UI: `apps/web/src/pages/settings/ModelsPage.tsx`
+
+---
+
+## Notes
+
+### WSL2 Claude CLI Path Workaround (Phase 16A)
+
+**Issue:** The Claude Agent SDK uses a pre-compiled binary that crashes on WSL2 due to glibc/syscall incompatibilities ([Issue #20](https://github.com/anthropics/claude-agent-sdk-typescript/issues/20), [Issue #5823](https://github.com/anthropics/claude-code/issues/5823)).
+
+**Workaround:** Use `pathToClaudeCodeExecutable` pointing to the npm/pnpm-installed Claude Code CLI (JavaScript-based), not the native binary.
+
+**Current Implementation:**
+```typescript
+const CLAUDE_CLI_PATH = process.env.CLAUDE_CLI_PATH || 'claude';
+```
+
+**For WSL2 users:** Set `CLAUDE_CLI_PATH` environment variable to the pnpm-installed path:
+```bash
+export CLAUDE_CLI_PATH="/home/<username>/.local/share/pnpm/claude"
+```
+
+**For non-WSL2 users:** The default `'claude'` (in PATH) works if Claude Code is installed via npm/pnpm globally.
+
+**CodeRabbit Review Note:** The hardcoded path was flagged and changed to use env var with `'claude'` fallback. WSL2 users must set `CLAUDE_CLI_PATH` explicitly. This is documented but not enforced at runtime to avoid breaking non-WSL2 deployments.

--- a/docs/phases/phase-16/00_PHASE_16_OVERVIEW.md
+++ b/docs/phases/phase-16/00_PHASE_16_OVERVIEW.md
@@ -34,14 +34,16 @@ This document outlines the planned enhancements to Synthesis for multi-provider 
 **Goal:** Use same chat UI with switchable LLM providers
 
 **Providers to support:**
-| Provider | API Type | Tool Calling | Priority |
-|----------|----------|--------------|----------|
-| Anthropic | Native SDK | Yes | P0 |
-| OpenAI | OpenAI SDK | Yes | P0 |
-| Ollama | OpenAI-compatible | Limited | P0 |
-| Google | Google AI SDK | Yes | P1 |
-| GLM 4 (Z.AI) | OpenAI-compatible | TBD | P2 |
-| Kimi (Moonshot) | OpenAI-compatible | TBD | P2 |
+| Provider | Base URL | Models | Tool Support | Priority |
+|----------|----------|--------|--------------|----------|
+| Anthropic | `https://api.anthropic.com/v1` | claude-sonnet-4-5-20250929, claude-haiku-4-5-20251001, claude-opus-4-5-20251101, claude-3-5-haiku-latest | Yes | P0 |
+| OpenAI | `https://api.openai.com/v1` | gpt-4.1-nano, gpt-5-mini, gpt-5-nano, gpt-5.1-codex-mini | Yes | P0 |
+| Ollama | `http://localhost:11434/v1` | llama3.2, mistral, codellama, phi3, gpt-oss-20b | Limited | P0 |
+| Google | `https://generativelanguage.googleapis.com/v1beta` | gemini-3-pro-preview, gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro | Yes | P1 |
+| Z.AI (Zhipu) | `https://api.z.ai/api/paas/v4` | GLM-4.6, GLM-4.5-Air | Yes | P2 |
+| Moonshot | `https://api.moonshot.cn/v1` | kimi-k2-0905-preview, kimi-k2-thinking, kimi-k2-thinking-turbo | Yes | P2 |
+
+**Note:** Z.AI also has a coding-specific endpoint: `https://api.z.ai/api/coding/paas/v4`
 
 **Architecture:**
 
@@ -121,17 +123,52 @@ ChatProvider Interface
 | Anthropic | Native tool_use blocks |
 | OpenAI | function_call / tools |
 | Google | functionDeclarations |
+| Z.AI (Zhipu) | OpenAI-compatible tools |
+| Moonshot | OpenAI-compatible tools |
 | Ollama | Limited (depends on model) |
 
 ---
 
 ## Implementation Phases
 
-### Phase 16A: Foundation (Docker + SDK Test)
-1. Test Claude Agent SDK workaround
-2. If fails, create Docker service config for server
-3. Verify SDK works in Docker
-4. Create provider abstraction interface
+### Phase 16A: Foundation (SDK Swap)
+**Status:** SDK workaround test PASSED ✅ - No Docker fallback needed!
+
+**Commits:**
+1. ✅ `feat(phase-16a): test Claude Agent SDK workaround` - DONE
+2. `feat(phase-16a): replace Anthropic SDK with Claude Agent SDK`
+
+**Remaining Tasks:**
+1. Replace `@anthropic-ai/sdk` with `@anthropic-ai/claude-code` in agent.ts
+2. Use `query()` with `pathToClaudeCodeExecutable: '/home/kngpnn/.local/share/pnpm/claude'`
+3. Remove manual 10-turn agentic loop (SDK handles tool execution internally)
+4. Adapt tool definitions for Claude Agent SDK format if needed
+5. Update response parsing for new SDK structure
+6. Test with existing RAG tools (search_rag, add_document, etc.)
+7. Create ChatProvider interface and types in `services/chat-providers/`
+
+**Key Change:**
+```typescript
+// FROM: Manual Anthropic SDK + 10-turn loop
+import Anthropic from '@anthropic-ai/sdk';
+const response = await anthropic.messages.create({...});
+while (turn < maxTurns) { /* manual tool handling */ }
+
+// TO: Claude Agent SDK (handles loop internally)
+import { query } from '@anthropic-ai/claude-code';
+const result = await query({
+  prompt: userMessage,
+  options: { pathToClaudeCodeExecutable: '/home/kngpnn/.local/share/pnpm/claude' }
+});
+```
+
+**Files to modify:**
+- `apps/server/src/agent/agent.ts` - Main SDK swap
+- `apps/server/src/agent/tools.ts` - May need format changes
+- `apps/server/package.json` - Add `@anthropic-ai/claude-code` dependency
+
+**Skills:** `synthesis-architecture`, `llm-provider-integration`, `backend-development`
+**Subagents:** `Explore` (find existing agent patterns), `Plan` (design interface)
 
 ### Phase 16B: Multi-Provider Chat
 1. Implement ChatProvider interface
@@ -140,6 +177,9 @@ ChatProvider Interface
 4. Add OllamaChatProvider
 5. Wire up model selector to provider selection
 
+**Skills:** `synthesis-architecture`, `llm-provider-integration`
+**Subagents:** `Explore` (research patterns), `test-writer` (provider tests), `code-reviewer` (after implementation)
+
 ### Phase 16C: Streaming & UI
 1. Add SSE endpoint for streaming responses
 2. Implement optimistic message display
@@ -147,17 +187,33 @@ ChatProvider Interface
 4. Token-by-token rendering
 5. Progress for tool execution
 
+**Skills:** `sse-streaming`, `frontend-design`, `synthesis-architecture`
+**Subagents:** `frontend-ui-architect` (streaming UI), `Explore` (find React patterns), `test-writer` (E2E tests)
+
 ### Phase 16D: Tool Adapters
 1. Create tool format converter for OpenAI
 2. Create tool format converter for Google
 3. Test tool calling across providers
 4. Graceful fallback for non-tool providers
 
+**Skills:** `llm-provider-integration`, `synthesis-architecture`
+**Subagents:** `Explore` (tool format research), `test-writer` (tool calling tests), `code-reviewer`
+
 ### Phase 16E: Additional Providers
 1. Add Google AI provider
 2. Add OpenAI-compatible provider base
 3. Add GLM 4 (Z.AI) support
 4. Add Kimi (Moonshot) support
+
+**Skills:** `llm-provider-integration` (see references/google.md, zhipu.md, moonshot.md)
+**Subagents:** `context7-docs-fetcher` (latest SDK docs), `test-writer`, `code-reviewer`
+
+### Cross-Phase Resources
+**Throughout all phases:**
+- `git-github-workflow-manager` - PR creation and management
+- `doc-writer` - Update docs after each phase
+- `brainstorming` - Design decisions when multiple approaches exist
+- `planning` - Break down complex tasks
 
 ---
 
@@ -262,6 +318,65 @@ apps/web/src/
 3. Streaming tokens display in real-time
 4. RAG tools work with Anthropic and OpenAI
 5. Existing functionality unchanged
+
+---
+
+## GitHub Workflow
+
+### Branch Strategy
+- **Base branch:** `develop`
+- **Feature branch:** `feature/phase-16-multi-provider-chat`
+- All PRs target `develop`, merge to `main` only for stable releases
+
+### Commit Strategy
+Each sub-phase (16A, 16B, etc.) gets its own commits. Group related changes:
+
+| Phase | Commits | PR Strategy |
+|-------|---------|-------------|
+| 16A: Foundation | 1-2 commits (SDK test + provider interface) | Single PR |
+| 16B: Multi-Provider | 3-4 commits (interface + each provider) | Single PR |
+| 16C: Streaming & UI | 2-3 commits (backend SSE + frontend) | Single PR |
+| 16D: Tool Adapters | 1-2 commits (adapters + tests) | Single PR |
+| 16E: Additional Providers | 1 commit per provider | Single PR |
+
+### Workflow Steps
+
+1. **Start work on a sub-phase:**
+   ```bash
+   git checkout develop && git pull
+   git checkout -b feature/phase-16-multi-provider-chat
+   ```
+
+2. **Commit logical units of work:**
+   ```bash
+   # After completing provider interface
+   git add -A && git commit -m "feat(phase-16a): add ChatProvider interface and types"
+
+   # After completing Anthropic provider
+   git add -A && git commit -m "feat(phase-16b): implement AnthropicChatProvider"
+   ```
+
+3. **Push and create PR when sub-phase complete:**
+   ```bash
+   git push -u origin feature/phase-16-multi-provider-chat
+   gh pr create --base develop --title "feat(phase-16a): foundation and provider interface"
+   ```
+
+4. **After PR merge, continue on same branch or create new:**
+   ```bash
+   git checkout develop && git pull
+   # Continue on same branch for related work, or create new branch
+   ```
+
+### Commit Message Format
+```text
+feat(phase-16X): short description
+
+- Detail 1
+- Detail 2
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
 
 ---
 

--- a/docs/phases/phase-16/PHASE_16_MULTI-PROVIDER-SUMMARY.md
+++ b/docs/phases/phase-16/PHASE_16_MULTI-PROVIDER-SUMMARY.md
@@ -1,0 +1,179 @@
+# Phase 16 Multi-Provider Chat - Implementation Summary
+
+## Overview
+
+This document tracks the implementation progress of Phase 16: Multi-Provider Chat & UI Improvements.
+
+---
+
+## Phase 16A: Claude Agent SDK Migration - COMPLETED
+
+**Status:** COMPLETED
+**Branch:** `feature/phase-16-multi-provider-chat`
+**Date:** 2025-12-06
+
+### Commits
+
+1. **38bbb3b** - `feat(phase-16a): add ChatProvider interface and test SDK workaround`
+   - Tested Claude Agent SDK with `pathToClaudeCodeExecutable` workaround
+   - Created ChatProvider interface and types
+   - Added tool format adapters
+   - Created provider registry pattern
+
+2. **Pending commit** - `feat(phase-16a): migrate agent to Claude Agent SDK query()`
+   - Replaced manual Anthropic SDK 10-turn loop with SDK's `query()` function
+   - Added `buildAgentMcpServer()` with 9 MCP tools
+   - Kept legacy `buildAgentTools()` for backward compatibility
+   - Updated tests with SDK mocks and MCP format validation
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `apps/server/src/agent/agent.ts` | Replaced Anthropic SDK with Claude Agent SDK `query()` |
+| `apps/server/src/agent/tools.ts` | Added MCP tool format (`buildAgentMcpServer()`, 9 tools) |
+| `apps/server/src/agent/__tests__/agent.test.ts` | Updated mocks for Claude Agent SDK |
+| `apps/server/src/agent/__tests__/tools.test.ts` | Added MCP server format tests |
+| `apps/server/src/services/chat-providers/types.ts` | ChatProvider interface and types |
+| `apps/server/src/services/chat-providers/adapters.ts` | Tool format adapters |
+| `apps/server/src/services/chat-providers/index.ts` | Provider registry |
+
+### Key Changes
+
+#### Before (Manual Anthropic SDK)
+```typescript
+import Anthropic from '@anthropic-ai/sdk';
+
+const anthropic = new Anthropic();
+let turn = 0;
+while (turn < maxTurns) {
+  const response = await anthropic.messages.create({...});
+  // Manual tool handling
+  turn++;
+}
+```
+
+#### After (Claude Agent SDK)
+```typescript
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import { buildAgentMcpServer, MCP_SERVER_NAME, MCP_TOOL_NAMES } from './tools.js';
+
+const mcpServer = buildAgentMcpServer(db, { collectionId });
+const response = query({
+  prompt,
+  options: {
+    pathToClaudeCodeExecutable: CLAUDE_CLI_PATH,
+    systemPrompt,
+    model: chatConfig.model,
+    mcpServers: { [MCP_SERVER_NAME]: mcpServer },
+    allowedTools: [...MCP_TOOL_NAMES],
+    permissionMode: 'bypassPermissions',
+    maxTurns: 10,
+  },
+});
+
+for await (const message of response) {
+  // Handle: system, assistant, user (tool_use/tool_result), result
+}
+```
+
+### MCP Tool Format
+
+**Server name:** `synthesis-rag-tools`
+
+**Tools (9 total):**
+- `mcp__synthesis-rag-tools__search_rag`
+- `mcp__synthesis-rag-tools__add_document`
+- `mcp__synthesis-rag-tools__fetch_web_content`
+- `mcp__synthesis-rag-tools__list_collections`
+- `mcp__synthesis-rag-tools__list_documents`
+- `mcp__synthesis-rag-tools__get_document_status`
+- `mcp__synthesis-rag-tools__delete_document`
+- `mcp__synthesis-rag-tools__restart_ingest`
+- `mcp__synthesis-rag-tools__summarize_document`
+
+### Verification
+
+| Check | Status |
+|-------|--------|
+| `pnpm typecheck:server` | PASS |
+| Agent tests (19 tests) | PASS |
+| Tools tests (14 tests) | PASS |
+| Manual integration test | PASS |
+
+### WSL2 Workaround
+
+The Claude Agent SDK binary crashes on WSL2. The workaround uses the npm/pnpm-installed Claude Code CLI:
+
+```typescript
+const CLAUDE_CLI_PATH = process.env.CLAUDE_CLI_PATH || 'claude';
+```
+
+**WSL2 users:** Set `CLAUDE_CLI_PATH=/home/<username>/.local/share/pnpm/claude`
+
+See: [Issue #20](https://github.com/anthropics/claude-agent-sdk-typescript/issues/20), [Issue #5823](https://github.com/anthropics/claude-code/issues/5823)
+
+---
+
+## Phase 16B: Multi-Provider Chat - NOT STARTED
+
+**Planned work:**
+1. Implement ChatProvider interface for each provider
+2. Add AnthropicChatProvider (uses Claude Agent SDK)
+3. Add OpenAIChatProvider
+4. Add OllamaChatProvider
+5. Wire up model selector to provider selection
+
+---
+
+## Phase 16C: Streaming & UI - NOT STARTED
+
+**Planned work:**
+1. Add SSE endpoint for streaming responses
+2. Implement optimistic message display
+3. Add loading/typing indicators
+4. Token-by-token rendering
+5. Progress for tool execution
+
+---
+
+## Phase 16D: Tool Adapters - NOT STARTED
+
+**Planned work:**
+1. Create tool format converter for OpenAI
+2. Create tool format converter for Google
+3. Test tool calling across providers
+4. Graceful fallback for non-tool providers
+
+---
+
+## Phase 16E: Additional Providers - NOT STARTED
+
+**Planned work:**
+1. Add Google AI provider
+2. Add OpenAI-compatible provider base
+3. Add GLM 4 (Z.AI) support
+4. Add Kimi (Moonshot) support
+
+---
+
+## Dependencies Added
+
+- `@anthropic-ai/claude-agent-sdk` - Claude Agent SDK for agentic workflows
+
+---
+
+## Environment Variables
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `CLAUDE_CLI_PATH` | Path to Claude Code CLI (WSL2 workaround) | `'claude'` |
+| `ANTHROPIC_API_KEY` | Anthropic API key | Required |
+
+---
+
+## Next Steps
+
+1. Commit the pending Phase 16A changes
+2. Create PR for Phase 16A
+3. Begin Phase 16B: Multi-Provider Chat implementation

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -490,7 +490,7 @@ export type ModelFeature =
 /**
  * LLM providers
  */
-export type LLMProvider = 'anthropic' | 'openai' | 'ollama' | 'google';
+export type LLMProvider = 'anthropic' | 'openai' | 'ollama' | 'google' | 'zhipu' | 'moonshot';
 
 /**
  * Reranker providers
@@ -580,21 +580,21 @@ export const DEFAULT_MODEL_CONFIGS: Record<ModelFeature, Omit<ModelConfig, 'sour
   chat: {
     feature: 'chat',
     provider: 'anthropic',
-    model: 'claude-3-5-haiku-20241022',
+    model: 'claude-3-5-haiku-latest',
     localOnly: false,
     enabled: true,
   },
   summary: {
     feature: 'summary',
     provider: 'anthropic',
-    model: 'claude-3-5-haiku-20241022',
+    model: 'claude-3-5-haiku-latest',
     localOnly: false,
     enabled: true,
   },
   ocr: {
     feature: 'ocr',
     provider: 'anthropic',
-    model: 'claude-3-5-haiku-20241022',
+    model: 'claude-3-5-haiku-latest',
     localOnly: false,
     enabled: true,
   },
@@ -629,7 +629,7 @@ export const DEFAULT_MODEL_CONFIGS: Record<ModelFeature, Omit<ModelConfig, 'sour
   contradiction: {
     feature: 'contradiction',
     provider: 'anthropic',
-    model: 'claude-3-5-haiku-20241022',
+    model: 'claude-3-5-haiku-latest',
     localOnly: false,
     enabled: false,
   },
@@ -641,10 +641,10 @@ export const DEFAULT_MODEL_CONFIGS: Record<ModelFeature, Omit<ModelConfig, 'sour
 export const PROVIDER_INFO: Record<string, ProviderInfo> = {
   anthropic: {
     models: [
-      'claude-3-5-haiku-20241022',
-      'claude-3-5-sonnet-20241022',
-      'claude-3-opus-20240229',
-      'claude-sonnet-4-20250514',
+      'claude-sonnet-4-5-20250929',
+      'claude-haiku-4-5-20251001',
+      'claude-opus-4-5-20251101',
+      'claude-3-5-haiku-latest',
     ],
     requiresApiKey: true,
     apiKeyEnvVar: 'ANTHROPIC_API_KEY',
@@ -653,14 +653,13 @@ export const PROVIDER_INFO: Record<string, ProviderInfo> = {
   openai: {
     models: [
       // Chat models
-      'gpt-4o',
-      'gpt-4o-mini',
-      'gpt-4-turbo',
-      'gpt-5-mini-2025-08-07',
-      'gpt-5-nano-2025-08-07',
+      'gpt-4.1-nano',
+      'gpt-5-mini',
+      'gpt-5-nano',
+      'gpt-5.1-codex-mini',
       // Embedding models
       'text-embedding-3-large',
-      'text-embedding-3-small',
+      'text-embedding-ada-002',
     ],
     requiresApiKey: true,
     apiKeyEnvVar: 'OPENAI_API_KEY',
@@ -670,12 +669,15 @@ export const PROVIDER_INFO: Record<string, ProviderInfo> = {
     models: [
       // Embedding models
       'nomic-embed-text',
+      'manutic/nomic-embed-code:latest',
       // Chat models
       'llama3.2',
       'mistral',
       'codellama',
       'phi3',
       'gpt-oss-20b',
+      // OCR models
+      'DeepSeek-OCR',
     ],
     requiresApiKey: false,
     isLocal: true,
@@ -683,18 +685,30 @@ export const PROVIDER_INFO: Record<string, ProviderInfo> = {
   google: {
     models: [
       // Chat models
-      'gemini-1.5-pro',
-      'gemini-1.5-flash',
-      'gemini-2.5-flash-lite',
+      'gemini-3-pro-preview',
       'gemini-2.5-flash',
+      'gemini-2.5-flash-lite',
+      'gemini-2.5-pro',
       // Vision models
-      'gemini-2.5-flash-image',
+      'gemini-3-pro-image-preview',
       // Embedding models
       'text-embedding-004',
       'gemini-embedding-001',
     ],
     requiresApiKey: true,
     apiKeyEnvVar: 'GOOGLE_API_KEY',
+    isLocal: false,
+  },
+  zhipu: {
+    models: ['GLM-4.6', 'GLM-4.5-Air'],
+    requiresApiKey: true,
+    apiKeyEnvVar: 'ZHIPU_API_KEY',
+    isLocal: false,
+  },
+  moonshot: {
+    models: ['kimi-k2-0905-preview', 'kimi-k2-thinking', 'kimi-k2-thinking-turbo'],
+    requiresApiKey: true,
+    apiKeyEnvVar: 'MOONSHOT_API_KEY',
     isLocal: false,
   },
   voyage: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
 
   apps/server:
     dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.1.59
+        version: 0.1.59(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.65.0
         version: 0.65.0(zod@3.25.76)
@@ -334,6 +337,12 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@anthropic-ai/claude-agent-sdk@0.1.59':
+    resolution: {integrity: sha512-9TMxQCkIOd9W3c+owLtTW7d1ZgWeYoz1tbUwqz1TiKJTZmsmAFHUfXebQsJBZ+W15g6msqA6ln9yYxOKlNnlGw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.24.1
 
   '@anthropic-ai/sdk@0.65.0':
     resolution: {integrity: sha512-zIdPOcrCVEI8t3Di40nH4z9EoeyGZfXbYSvWdDLsB/KkaSYMnEgC7gmcgWu83g2NTn1ZTpbMvpdttWDGGIk6zw==}
@@ -1176,6 +1185,89 @@ packages:
   '@huggingface/jinja@0.2.2':
     resolution: {integrity: sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==}
     engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.33.5':
+    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.33.5':
+    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.33.5':
+    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.33.5':
+    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.33.5':
+    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-win32-x64@0.33.5':
+    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@ioredis/commands@1.4.0':
     resolution: {integrity: sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==}
@@ -5240,6 +5332,19 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@anthropic-ai/claude-agent-sdk@0.1.59(zod@3.25.76)':
+    dependencies:
+      zod: 3.25.76
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.33.5
+      '@img/sharp-darwin-x64': 0.33.5
+      '@img/sharp-linux-arm': 0.33.5
+      '@img/sharp-linux-arm64': 0.33.5
+      '@img/sharp-linux-x64': 0.33.5
+      '@img/sharp-linuxmusl-arm64': 0.33.5
+      '@img/sharp-linuxmusl-x64': 0.33.5
+      '@img/sharp-win32-x64': 0.33.5
+
   '@anthropic-ai/sdk@0.65.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
@@ -6226,6 +6331,65 @@ snapshots:
   '@gar/promisify@1.1.3': {}
 
   '@huggingface/jinja@0.2.2': {}
+
+  '@img/sharp-darwin-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.0.5
+    optional: true
+
+  '@img/sharp-linux-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-win32-x64@0.33.5':
+    optional: true
 
   '@ioredis/commands@1.4.0': {}
 


### PR DESCRIPTION
## Summary

Phase 16A implementation: Migrate from manual Anthropic SDK to Claude Agent SDK and establish ChatProvider foundation for multi-provider chat support.

### Changes

**Commit 1: ChatProvider Interface and SDK Test (38bbb3b)**
- Add ChatProvider interface and types (`services/chat-providers/types.ts`)
- Add tool format adapters for cross-provider compatibility (`services/chat-providers/adapters.ts`)
- Add provider registry pattern (`services/chat-providers/index.ts`)
- Test Claude Agent SDK workaround with `pathToClaudeCodeExecutable`
- Add `@anthropic-ai/claude-agent-sdk` dependency

**Commit 2: Agent SDK Migration (90b9ee1)**
- Replace manual 10-turn Anthropic SDK loop with SDK's `query()` function
- Add `buildAgentMcpServer()` with 9 MCP tools in `tools.ts`
- Keep legacy `buildAgentTools()` for backward compatibility
- Update tests with SDK mocks and MCP format validation
- Add `MCP_SERVER_NAME` and `MCP_TOOL_NAMES` exports
- Use `CLAUDE_CLI_PATH` env var with `'claude'` fallback (WSL2 workaround)
- Document WSL2 workaround in Phase 16 overview
- Add Phase 16 multi-provider summary document

### Files Changed

| File | Description |
|------|-------------|
| `apps/server/src/agent/agent.ts` | Use Claude Agent SDK `query()` |
| `apps/server/src/agent/tools.ts` | Add MCP tool format |
| `apps/server/src/services/chat-providers/` | Provider interface & registry |
| `apps/server/src/agent/__tests__/` | Updated test mocks |
| `docs/phases/phase-16/` | Documentation updates |

### MCP Tools (9 total)
- `mcp__synthesis-rag-tools__search_rag`
- `mcp__synthesis-rag-tools__add_document`
- `mcp__synthesis-rag-tools__fetch_web_content`
- `mcp__synthesis-rag-tools__list_collections`
- `mcp__synthesis-rag-tools__list_documents`
- `mcp__synthesis-rag-tools__get_document_status`
- `mcp__synthesis-rag-tools__delete_document`
- `mcp__synthesis-rag-tools__restart_ingest`
- `mcp__synthesis-rag-tools__summarize_document`

## Test plan

- [x] `pnpm typecheck:server` passes
- [x] Agent tests pass (19 tests)
- [x] Tools tests pass (14 tests)
- [x] Manual integration test: Server starts, `/api/agent/chat` endpoint works
- [x] WSL2 workaround verified working

## Notes

**WSL2 Workaround:** The Claude Agent SDK binary crashes on WSL2. The workaround uses `CLAUDE_CLI_PATH` env var pointing to the npm/pnpm-installed Claude Code CLI. Non-WSL2 users can rely on the `'claude'` default (in PATH).

See: [Issue #20](https://github.com/anthropics/claude-agent-sdk-typescript/issues/20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-provider chat registry and adapters for Anthropic/Claude, OpenAI, Google, Zhipu, Moonshot, and local providers.

* **Improvements**
  * Swapped to Claude Agent SDK flow with MCP-style tool integration and standardized provider configs; updated default model lists.
  * Added Redis to dev workflow and unified startup/test commands.

* **Documentation**
  * Revamped Phase 16 docs and multi-provider summary with configuration and migration notes.

* **Tests**
  * Added WSL2 compatibility and comprehensive SDK/agent test coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->