### PR TITLE
feat(phase-16e): Add Google, Zhipu, and Moonshot chat providers

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -19,6 +19,7 @@
     "@fastify/compress": "^7.0.1",
     "@fastify/cors": "^9.0.1",
     "@fastify/multipart": "^8.3.0",
+    "@google/generative-ai": "^0.24.1",
     "@synthesis/db": "workspace:*",
     "@synthesis/shared": "workspace:*",
     "@voyageai/voyageai": "npm:voyageai@^0.0.8",

--- a/apps/server/src/services/chat-providers/__tests__/google.test.ts
+++ b/apps/server/src/services/chat-providers/__tests__/google.test.ts
@@ -1,0 +1,1093 @@
+/**
+ * Google Gemini Chat Provider Tests
+ *
+ * Phase 16B: Unit tests for GoogleChatProvider
+ * Tests the manual 10-turn tool execution loop and API integration.
+ */
+
+import type { Pool } from 'pg';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// =============================================================================
+// Hoisted Mocks
+// =============================================================================
+
+const mockGenerateContentStream = vi.hoisted(() => vi.fn());
+const mockBuildAgentTools = vi.hoisted(() => vi.fn());
+const mockGetProviderApiKey = vi.hoisted(() => vi.fn());
+
+// =============================================================================
+// Module Mocks
+// =============================================================================
+
+vi.mock('@google/generative-ai', () => ({
+  GoogleGenerativeAI: vi.fn().mockImplementation(() => ({
+    getGenerativeModel: vi.fn().mockImplementation(() => ({
+      generateContentStream: mockGenerateContentStream,
+    })),
+  })),
+  SchemaType: {
+    STRING: 'STRING',
+    NUMBER: 'NUMBER',
+    INTEGER: 'INTEGER',
+    BOOLEAN: 'BOOLEAN',
+    ARRAY: 'ARRAY',
+    OBJECT: 'OBJECT',
+  },
+}));
+
+vi.mock('../../../agent/tools.js', () => ({
+  __esModule: true,
+  buildAgentTools: mockBuildAgentTools,
+}));
+
+vi.mock('../index.js', async (importOriginal) => {
+  const original = (await importOriginal()) as object;
+  return {
+    ...original,
+    getProviderApiKey: mockGetProviderApiKey,
+  };
+});
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+function createMockPool(): Pool {
+  const query = vi.fn().mockResolvedValue({ rows: [] });
+  const connect = vi.fn().mockResolvedValue({
+    query: vi.fn().mockResolvedValue({ rows: [] }),
+    release: vi.fn(),
+  });
+
+  return {
+    query,
+    connect,
+  } as unknown as Pool;
+}
+
+function createMockToolExecutors() {
+  return {
+    search_rag: vi.fn().mockResolvedValue(JSON.stringify({ results: [] })),
+    add_document: vi.fn().mockResolvedValue(JSON.stringify({ id: 'doc-1' })),
+    fetch_web_content: vi.fn().mockResolvedValue(JSON.stringify({ fetched: true })),
+    list_collections: vi.fn().mockResolvedValue(JSON.stringify({ collections: [] })),
+    list_documents: vi.fn().mockResolvedValue(JSON.stringify({ documents: [] })),
+    get_document_status: vi.fn().mockResolvedValue(JSON.stringify({ status: 'complete' })),
+    delete_document: vi.fn().mockResolvedValue(JSON.stringify({ deleted: true })),
+    restart_ingest: vi.fn().mockResolvedValue(JSON.stringify({ restarted: true })),
+    summarize_document: vi.fn().mockResolvedValue(JSON.stringify({ summary: 'Test summary' })),
+  };
+}
+
+/**
+ * Create a mock Google Gemini response stream
+ * Yields chunks and then completes
+ */
+function createMockGoogleResponse(options: {
+  text?: string;
+  functionCalls?: Array<{ name: string; args: Record<string, unknown> }>;
+  finishReason?: string;
+  promptTokenCount?: number;
+  candidatesTokenCount?: number;
+}) {
+  const chunks: Array<{
+    candidates: Array<{
+      content?: { parts: Array<{ text?: string; functionCall?: unknown }> };
+      finishReason?: string;
+    }>;
+    usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number };
+  }> = [];
+
+  // Build response parts
+  const parts: Array<{ text?: string; functionCall?: unknown }> = [];
+
+  if (options.text) {
+    parts.push({ text: options.text });
+  }
+
+  if (options.functionCalls) {
+    for (const fc of options.functionCalls) {
+      parts.push({ functionCall: fc });
+    }
+  }
+
+  // Create chunk
+  chunks.push({
+    candidates: [
+      {
+        content: { parts },
+        finishReason: options.finishReason ?? 'STOP',
+      },
+    ],
+    usageMetadata: {
+      promptTokenCount: options.promptTokenCount ?? 100,
+      candidatesTokenCount: options.candidatesTokenCount ?? 50,
+    },
+  });
+
+  // Return async generator
+  return {
+    stream: (async function* () {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    })(),
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+let GoogleChatProvider: typeof import('../google.js')['GoogleChatProvider'];
+let createGoogleProvider: typeof import('../google.js')['createGoogleProvider'];
+
+describe('GoogleChatProvider', () => {
+  const mockPool = createMockPool();
+  const mockContext = { collectionId: '11111111-1111-4111-8111-111111111111' };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // Default API key configured
+    mockGetProviderApiKey.mockResolvedValue('test-google-key');
+
+    // Default tool executors
+    const mockExecutors = createMockToolExecutors();
+    mockBuildAgentTools.mockReturnValue({
+      tools: [],
+      toolExecutors: mockExecutors,
+    });
+
+    // Import after mocks are set up
+    const module = await import('../google.js');
+    GoogleChatProvider = module.GoogleChatProvider;
+    createGoogleProvider = module.createGoogleProvider;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ===========================================================================
+  // Provider Properties and Configuration Tests
+  // ===========================================================================
+
+  describe('provider properties', () => {
+    it('should have correct name', () => {
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      expect(provider.name).toBe('google');
+    });
+
+    it('should have correct capabilities', () => {
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      expect(provider.capabilities).toEqual({
+        supportsTools: true,
+        supportsStreaming: true,
+        supportsVision: true,
+        maxContextTokens: 1000000,
+      });
+    });
+  });
+
+  describe('isConfigured', () => {
+    it('should return true when API key is configured', async () => {
+      mockGetProviderApiKey.mockResolvedValue('test-api-key');
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+
+      const result = await provider.isConfigured();
+
+      expect(result).toBe(true);
+      expect(mockGetProviderApiKey).toHaveBeenCalledWith(mockPool, 'google');
+    });
+
+    it('should return false when API key is not configured', async () => {
+      mockGetProviderApiKey.mockResolvedValue(null);
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+
+      const result = await provider.isConfigured();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // Chat Without Tools Tests
+  // ===========================================================================
+
+  describe('chat without tools', () => {
+    it('should complete successfully with simple text response', async () => {
+      mockGenerateContentStream.mockResolvedValue(
+        createMockGoogleResponse({
+          text: 'Hello! How can I help you today?',
+          finishReason: 'STOP',
+          promptTokenCount: 50,
+          candidatesTokenCount: 15,
+        })
+      );
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      const result = await provider.chat({
+        messages: [{ role: 'user', content: 'Hello' }],
+        model: 'gemini-pro',
+      });
+
+      expect(result.content).toBe('Hello! How can I help you today?');
+      expect(result.toolCalls).toHaveLength(0);
+      expect(result.stopReason).toBe('end_turn');
+      expect(result.usage).toEqual({
+        inputTokens: 50,
+        outputTokens: 15,
+        totalTokens: 65,
+      });
+      expect(result.model).toBe('gemini-pro');
+      expect(result.provider).toBe('google');
+    });
+
+    it('should handle system prompt correctly', async () => {
+      const mockGetGenerativeModel = vi.fn().mockReturnValue({
+        generateContentStream: mockGenerateContentStream,
+      });
+
+      const GoogleGenerativeAI = await import('@google/generative-ai');
+      (
+        GoogleGenerativeAI.GoogleGenerativeAI as unknown as ReturnType<typeof vi.fn>
+      ).mockImplementation(() => ({
+        getGenerativeModel: mockGetGenerativeModel,
+      }));
+
+      mockGenerateContentStream.mockResolvedValue(
+        createMockGoogleResponse({
+          text: 'I am a helpful assistant.',
+        })
+      );
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      await provider.chat({
+        messages: [{ role: 'user', content: 'Who are you?' }],
+        model: 'gemini-pro',
+        systemPrompt: 'You are a helpful assistant.',
+      });
+
+      // Verify getGenerativeModel was called with systemInstruction
+      expect(mockGetGenerativeModel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          systemInstruction: 'You are a helpful assistant.',
+        })
+      );
+    });
+
+    it('should pass optional parameters correctly', async () => {
+      mockGenerateContentStream.mockResolvedValue(createMockGoogleResponse({ text: 'Response' }));
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      await provider.chat({
+        messages: [{ role: 'user', content: 'Test' }],
+        model: 'gemini-pro',
+        maxTokens: 1000,
+        temperature: 0.7,
+        stopSequences: ['END'],
+      });
+
+      expect(mockGenerateContentStream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          generationConfig: {
+            maxOutputTokens: 1000,
+            temperature: 0.7,
+            stopSequences: ['END'],
+          },
+        })
+      );
+    });
+
+    it('should handle empty content response', async () => {
+      mockGenerateContentStream.mockResolvedValue(
+        createMockGoogleResponse({
+          finishReason: 'STOP',
+        })
+      );
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      const result = await provider.chat({
+        messages: [{ role: 'user', content: 'Test' }],
+        model: 'gemini-pro',
+      });
+
+      expect(result.content).toBe('');
+    });
+  });
+
+  // ===========================================================================
+  // Chat With Tool Execution Tests
+  // ===========================================================================
+
+  describe('chat with tool execution', () => {
+    const mockTools = [
+      {
+        name: 'search_rag',
+        description: 'Search the knowledge base',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            query: { type: 'string' },
+          },
+          required: ['query'],
+        },
+      },
+    ];
+
+    it('should execute single tool and return final response', async () => {
+      const toolExecutors = createMockToolExecutors();
+      toolExecutors.search_rag.mockResolvedValue(
+        JSON.stringify({ results: [{ text: 'Found result' }] })
+      );
+      mockBuildAgentTools.mockReturnValue({
+        tools: [],
+        toolExecutors,
+      });
+
+      // First call: model wants to use a tool
+      mockGenerateContentStream
+        .mockResolvedValueOnce(
+          createMockGoogleResponse({
+            functionCalls: [
+              {
+                name: 'search_rag',
+                args: { query: 'test query' },
+              },
+            ],
+            finishReason: 'STOP',
+          })
+        )
+        // Second call: model returns final response after tool execution
+        .mockResolvedValueOnce(
+          createMockGoogleResponse({
+            text: 'Based on the search results, I found relevant information.',
+            finishReason: 'STOP',
+          })
+        );
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      const result = await provider.chat({
+        messages: [{ role: 'user', content: 'Search for test query' }],
+        model: 'gemini-pro',
+        tools: mockTools,
+      });
+
+      expect(toolExecutors.search_rag).toHaveBeenCalledWith({ query: 'test query' });
+      expect(result.content).toBe('Based on the search results, I found relevant information.');
+      expect(mockGenerateContentStream).toHaveBeenCalledTimes(2);
+    });
+
+    it('should execute multiple tools in a single turn', async () => {
+      const toolExecutors = createMockToolExecutors();
+      mockBuildAgentTools.mockReturnValue({
+        tools: [],
+        toolExecutors,
+      });
+
+      // First call: model wants to use multiple tools
+      mockGenerateContentStream
+        .mockResolvedValueOnce(
+          createMockGoogleResponse({
+            functionCalls: [
+              {
+                name: 'search_rag',
+                args: { query: 'query 1' },
+              },
+              {
+                name: 'list_documents',
+                args: {},
+              },
+            ],
+            finishReason: 'STOP',
+          })
+        )
+        .mockResolvedValueOnce(
+          createMockGoogleResponse({
+            text: 'Completed both searches.',
+            finishReason: 'STOP',
+          })
+        );
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      const result = await provider.chat({
+        messages: [{ role: 'user', content: 'Search and list docs' }],
+        model: 'gemini-pro',
+        tools: mockTools,
+      });
+
+      expect(toolExecutors.search_rag).toHaveBeenCalled();
+      expect(toolExecutors.list_documents).toHaveBeenCalled();
+      expect(result.content).toBe('Completed both searches.');
+    });
+
+    it('should handle multi-turn tool execution loop', async () => {
+      const toolExecutors = createMockToolExecutors();
+      mockBuildAgentTools.mockReturnValue({
+        tools: [],
+        toolExecutors,
+      });
+
+      // Turn 1: First tool call
+      mockGenerateContentStream
+        .mockResolvedValueOnce(
+          createMockGoogleResponse({
+            functionCalls: [
+              {
+                name: 'search_rag',
+                args: { query: 'first query' },
+              },
+            ],
+            finishReason: 'STOP',
+          })
+        )
+        // Turn 2: Second tool call based on first results
+        .mockResolvedValueOnce(
+          createMockGoogleResponse({
+            functionCalls: [
+              {
+                name: 'get_document_status',
+                args: { doc_id: 'doc-1' },
+              },
+            ],
+            finishReason: 'STOP',
+          })
+        )
+        // Turn 3: Final response
+        .mockResolvedValueOnce(
+          createMockGoogleResponse({
+            text: 'After multiple tool calls, here is the answer.',
+            finishReason: 'STOP',
+          })
+        );
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      const result = await provider.chat({
+        messages: [{ role: 'user', content: 'Complex query' }],
+        model: 'gemini-pro',
+        tools: mockTools,
+      });
+
+      expect(mockGenerateContentStream).toHaveBeenCalledTimes(3);
+      expect(toolExecutors.search_rag).toHaveBeenCalled();
+      expect(toolExecutors.get_document_status).toHaveBeenCalled();
+      expect(result.content).toBe('After multiple tool calls, here is the answer.');
+    });
+
+    it('should convert tools to Google functionDeclaration format', async () => {
+      mockGenerateContentStream.mockResolvedValue(
+        createMockGoogleResponse({
+          text: 'Response',
+          finishReason: 'STOP',
+        })
+      );
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      await provider.chat({
+        messages: [{ role: 'user', content: 'Test' }],
+        model: 'gemini-pro',
+        tools: mockTools,
+      });
+
+      expect(mockGenerateContentStream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tools: [
+            {
+              functionDeclarations: [
+                {
+                  name: 'search_rag',
+                  description: 'Search the knowledge base',
+                  parameters: {
+                    type: 'OBJECT',
+                    properties: {
+                      query: { type: 'STRING' },
+                    },
+                    required: ['query'],
+                  },
+                },
+              ],
+            },
+          ],
+        })
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Max Turns Limit Tests
+  // ===========================================================================
+
+  describe('max turns limit', () => {
+    it('should reach max turns (10) and complete', async () => {
+      const toolExecutors = createMockToolExecutors();
+      mockBuildAgentTools.mockReturnValue({
+        tools: [],
+        toolExecutors,
+      });
+
+      // Create a persistent mock that returns function calls for first 10 calls
+      // then returns text to exit loop
+      let callCount = 0;
+      mockGenerateContentStream.mockImplementation(() => {
+        callCount++;
+        return createMockGoogleResponse({
+          functionCalls: [
+            {
+              name: 'search_rag',
+              args: { query: 'loop' },
+            },
+          ],
+          finishReason: 'STOP',
+        });
+      });
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+
+      const result = await provider.chat({
+        messages: [{ role: 'user', content: 'Trigger loop' }],
+        model: 'gemini-pro',
+        tools: [
+          {
+            name: 'search_rag',
+            description: 'Search',
+            inputSchema: {
+              type: 'object',
+              properties: {},
+            },
+          },
+        ],
+      });
+
+      // Should have called 10 times (max turns limit)
+      expect(mockGenerateContentStream).toHaveBeenCalledTimes(10);
+      // Should complete gracefully with end_turn after max turns
+      expect(result.stopReason).toBe('end_turn');
+      // Usage should be 0 when max turns reached (as per implementation)
+      expect(result.usage.totalTokens).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // Error Handling Tests
+  // ===========================================================================
+
+  describe('error handling', () => {
+    it('should throw error when API key is not configured', async () => {
+      mockGetProviderApiKey.mockResolvedValue(null);
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+
+      await expect(
+        provider.chat({
+          messages: [{ role: 'user', content: 'Test' }],
+          model: 'gemini-pro',
+        })
+      ).rejects.toThrow('Google API key not configured');
+    });
+
+    it('should handle response with no candidates', async () => {
+      mockGenerateContentStream.mockResolvedValue({
+        stream: (async function* () {
+          yield { candidates: [] };
+        })(),
+      });
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      const result = await provider.chat({
+        messages: [{ role: 'user', content: 'Test' }],
+        model: 'gemini-pro',
+      });
+
+      // Should return empty content
+      expect(result.content).toBe('');
+    });
+
+    it('should handle tool execution errors gracefully', async () => {
+      const toolExecutors = createMockToolExecutors();
+      toolExecutors.search_rag.mockRejectedValue(new Error('Tool execution failed'));
+      mockBuildAgentTools.mockReturnValue({
+        tools: [],
+        toolExecutors,
+      });
+
+      // First call: tool call that will fail
+      mockGenerateContentStream
+        .mockResolvedValueOnce(
+          createMockGoogleResponse({
+            functionCalls: [
+              {
+                name: 'search_rag',
+                args: { query: 'fail' },
+              },
+            ],
+            finishReason: 'STOP',
+          })
+        )
+        // Second call: model handles error and responds
+        .mockResolvedValueOnce(
+          createMockGoogleResponse({
+            text: 'I encountered an error with the search tool.',
+            finishReason: 'STOP',
+          })
+        );
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      const result = await provider.chat({
+        messages: [{ role: 'user', content: 'Search' }],
+        model: 'gemini-pro',
+        tools: [
+          {
+            name: 'search_rag',
+            description: 'Search',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+      });
+
+      // Should complete despite tool error
+      expect(result.content).toBe('I encountered an error with the search tool.');
+
+      // Verify error was passed as function response
+      const secondCall = mockGenerateContentStream.mock.calls[1];
+      const contents = secondCall[0].contents;
+      const functionResponseMsg = contents.find(
+        (c: { role: string; parts: Array<{ functionResponse?: unknown }> }) =>
+          c.role === 'user' &&
+          c.parts.some((p: { functionResponse?: unknown }) => p.functionResponse)
+      );
+      expect(functionResponseMsg).toBeDefined();
+    });
+
+    it('should handle unknown tool gracefully', async () => {
+      const toolExecutors = createMockToolExecutors();
+      mockBuildAgentTools.mockReturnValue({
+        tools: [],
+        toolExecutors,
+      });
+
+      mockGenerateContentStream
+        .mockResolvedValueOnce(
+          createMockGoogleResponse({
+            functionCalls: [
+              {
+                name: 'unknown_tool',
+                args: {},
+              },
+            ],
+            finishReason: 'STOP',
+          })
+        )
+        .mockResolvedValueOnce(
+          createMockGoogleResponse({
+            text: 'I do not recognize that tool.',
+            finishReason: 'STOP',
+          })
+        );
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      const result = await provider.chat({
+        messages: [{ role: 'user', content: 'Use unknown tool' }],
+        model: 'gemini-pro',
+        tools: [
+          {
+            name: 'unknown_tool',
+            description: 'Unknown',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+      });
+
+      expect(result.content).toBe('I do not recognize that tool.');
+
+      // Verify error was passed as function response
+      const secondCall = mockGenerateContentStream.mock.calls[1];
+      const contents = secondCall[0].contents;
+      const functionResponseMsg = contents.find(
+        (c: { role: string; parts: Array<{ functionResponse?: unknown }> }) =>
+          c.role === 'user' &&
+          c.parts.some((p: { functionResponse?: unknown }) => p.functionResponse)
+      );
+      expect(functionResponseMsg).toBeDefined();
+    });
+
+    it('should handle non-Error exceptions in tool execution', async () => {
+      const toolExecutors = createMockToolExecutors();
+      toolExecutors.search_rag.mockRejectedValue('String error');
+      mockBuildAgentTools.mockReturnValue({
+        tools: [],
+        toolExecutors,
+      });
+
+      mockGenerateContentStream
+        .mockResolvedValueOnce(
+          createMockGoogleResponse({
+            functionCalls: [
+              {
+                name: 'search_rag',
+                args: {},
+              },
+            ],
+            finishReason: 'STOP',
+          })
+        )
+        .mockResolvedValueOnce(
+          createMockGoogleResponse({
+            text: 'Handled error.',
+            finishReason: 'STOP',
+          })
+        );
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      const result = await provider.chat({
+        messages: [{ role: 'user', content: 'Test' }],
+        model: 'gemini-pro',
+        tools: [
+          {
+            name: 'search_rag',
+            description: 'Search',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+      });
+
+      expect(result.content).toBe('Handled error.');
+
+      // Verify error message was used
+      const secondCall = mockGenerateContentStream.mock.calls[1];
+      const contents = secondCall[0].contents;
+      const functionResponseMsg = contents.find(
+        (c: { role: string; parts: Array<{ functionResponse?: unknown }> }) =>
+          c.role === 'user' &&
+          c.parts.some((p: { functionResponse?: unknown }) => p.functionResponse)
+      );
+      expect(functionResponseMsg).toBeDefined();
+    });
+  });
+
+  // ===========================================================================
+  // Stop Reason Mapping Tests
+  // ===========================================================================
+
+  describe('stop reason mapping', () => {
+    it('should map "STOP" to "end_turn"', async () => {
+      mockGenerateContentStream.mockResolvedValue(
+        createMockGoogleResponse({
+          text: 'Response',
+          finishReason: 'STOP',
+        })
+      );
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      const result = await provider.chat({
+        messages: [{ role: 'user', content: 'Test' }],
+        model: 'gemini-pro',
+      });
+
+      expect(result.stopReason).toBe('end_turn');
+    });
+
+    it('should map "MAX_TOKENS" to "max_tokens"', async () => {
+      mockGenerateContentStream.mockResolvedValue(
+        createMockGoogleResponse({
+          text: 'Truncated response...',
+          finishReason: 'MAX_TOKENS',
+        })
+      );
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      const result = await provider.chat({
+        messages: [{ role: 'user', content: 'Test' }],
+        model: 'gemini-pro',
+      });
+
+      expect(result.stopReason).toBe('max_tokens');
+    });
+
+    it('should map "SAFETY" to "end_turn"', async () => {
+      mockGenerateContentStream.mockResolvedValue(
+        createMockGoogleResponse({
+          text: 'Response',
+          finishReason: 'SAFETY',
+        })
+      );
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      const result = await provider.chat({
+        messages: [{ role: 'user', content: 'Test' }],
+        model: 'gemini-pro',
+      });
+
+      expect(result.stopReason).toBe('end_turn');
+    });
+
+    it('should map unknown reason to "end_turn"', async () => {
+      mockGenerateContentStream.mockResolvedValue(
+        createMockGoogleResponse({
+          text: 'Response',
+          finishReason: 'UNKNOWN_REASON',
+        })
+      );
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      const result = await provider.chat({
+        messages: [{ role: 'user', content: 'Test' }],
+        model: 'gemini-pro',
+      });
+
+      expect(result.stopReason).toBe('end_turn');
+    });
+  });
+
+  // ===========================================================================
+  // Factory Function Tests
+  // ===========================================================================
+
+  describe('createGoogleProvider factory', () => {
+    it('should create a GoogleChatProvider instance', () => {
+      const provider = createGoogleProvider(mockPool, mockContext);
+
+      expect(provider).toBeInstanceOf(GoogleChatProvider);
+      expect(provider.name).toBe('google');
+    });
+  });
+
+  // ===========================================================================
+  // Message Conversion Tests
+  // ===========================================================================
+
+  describe('message conversion', () => {
+    it('should convert user messages correctly', async () => {
+      mockGenerateContentStream.mockResolvedValue(createMockGoogleResponse({ text: 'Response' }));
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      await provider.chat({
+        messages: [
+          { role: 'user', content: 'First message' },
+          { role: 'assistant', content: 'First response' },
+          { role: 'user', content: 'Second message' },
+        ],
+        model: 'gemini-pro',
+      });
+
+      expect(mockGenerateContentStream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          contents: expect.arrayContaining([
+            expect.objectContaining({ role: 'user', parts: [{ text: 'First message' }] }),
+            expect.objectContaining({ role: 'model', parts: [{ text: 'First response' }] }),
+            expect.objectContaining({ role: 'user', parts: [{ text: 'Second message' }] }),
+          ]),
+        })
+      );
+    });
+
+    it('should skip system messages in contents', async () => {
+      mockGenerateContentStream.mockResolvedValue(createMockGoogleResponse({ text: 'Response' }));
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      await provider.chat({
+        messages: [
+          { role: 'system', content: 'You are helpful' },
+          { role: 'user', content: 'Hello' },
+        ],
+        model: 'gemini-pro',
+      });
+
+      const call = mockGenerateContentStream.mock.calls[0][0];
+      const contents = call.contents;
+
+      // Should only have user message, system handled via systemInstruction
+      expect(contents).toHaveLength(1);
+      expect(contents[0].role).toBe('user');
+    });
+  });
+
+  // ===========================================================================
+  // Usage Tracking Tests
+  // ===========================================================================
+
+  describe('usage tracking', () => {
+    it('should track token usage correctly', async () => {
+      mockGenerateContentStream.mockResolvedValue(
+        createMockGoogleResponse({
+          text: 'Response',
+          promptTokenCount: 200,
+          candidatesTokenCount: 100,
+        })
+      );
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      const result = await provider.chat({
+        messages: [{ role: 'user', content: 'Test' }],
+        model: 'gemini-pro',
+      });
+
+      expect(result.usage).toEqual({
+        inputTokens: 200,
+        outputTokens: 100,
+        totalTokens: 300,
+      });
+    });
+
+    it('should handle missing usage metadata', async () => {
+      mockGenerateContentStream.mockResolvedValue({
+        stream: (async function* () {
+          yield {
+            candidates: [
+              {
+                content: { parts: [{ text: 'Response' }] },
+                finishReason: 'STOP',
+              },
+            ],
+            // No usageMetadata
+          };
+        })(),
+      });
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      const result = await provider.chat({
+        messages: [{ role: 'user', content: 'Test' }],
+        model: 'gemini-pro',
+      });
+
+      expect(result.usage).toEqual({
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+      });
+    });
+  });
+
+  // ===========================================================================
+  // Streaming Tests
+  // ===========================================================================
+
+  describe('streamChat', () => {
+    it('should yield text chunks during streaming', async () => {
+      mockGenerateContentStream.mockResolvedValue(
+        createMockGoogleResponse({
+          text: 'Streaming response',
+          finishReason: 'STOP',
+        })
+      );
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      const chunks = [];
+
+      for await (const chunk of provider.streamChat({
+        messages: [{ role: 'user', content: 'Test' }],
+        model: 'gemini-pro',
+      })) {
+        chunks.push(chunk);
+      }
+
+      // Should have text chunk and done chunk
+      expect(chunks.some((c) => c.type === 'text')).toBe(true);
+      expect(chunks.some((c) => c.type === 'done')).toBe(true);
+    });
+
+    it('should yield tool_start and tool_end chunks', async () => {
+      const toolExecutors = createMockToolExecutors();
+      mockBuildAgentTools.mockReturnValue({
+        tools: [],
+        toolExecutors,
+      });
+
+      mockGenerateContentStream
+        .mockResolvedValueOnce(
+          createMockGoogleResponse({
+            functionCalls: [
+              {
+                name: 'search_rag',
+                args: { query: 'test' },
+              },
+            ],
+            finishReason: 'STOP',
+          })
+        )
+        .mockResolvedValueOnce(
+          createMockGoogleResponse({
+            text: 'Done',
+            finishReason: 'STOP',
+          })
+        );
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      const chunks = [];
+
+      for await (const chunk of provider.streamChat({
+        messages: [{ role: 'user', content: 'Search' }],
+        model: 'gemini-pro',
+        tools: [
+          {
+            name: 'search_rag',
+            description: 'Search',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+      })) {
+        chunks.push(chunk);
+      }
+
+      // Should have tool_start, tool_end, text, and done chunks
+      expect(chunks.some((c) => c.type === 'tool_start')).toBe(true);
+      expect(chunks.some((c) => c.type === 'tool_end')).toBe(true);
+      expect(chunks.some((c) => c.type === 'text')).toBe(true);
+      expect(chunks.some((c) => c.type === 'done')).toBe(true);
+    });
+  });
+
+  // ===========================================================================
+  // Schema Conversion Tests
+  // ===========================================================================
+
+  describe('schema conversion', () => {
+    it('should convert complex schema types correctly', async () => {
+      mockGenerateContentStream.mockResolvedValue(createMockGoogleResponse({ text: 'Response' }));
+
+      const provider = new GoogleChatProvider(mockPool, mockContext);
+      await provider.chat({
+        messages: [{ role: 'user', content: 'Test' }],
+        model: 'gemini-pro',
+        tools: [
+          {
+            name: 'complex_tool',
+            description: 'Complex tool',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                stringParam: { type: 'string' },
+                numberParam: { type: 'number' },
+                integerParam: { type: 'integer' },
+                booleanParam: { type: 'boolean' },
+                arrayParam: {
+                  type: 'array',
+                  items: { type: 'string' },
+                },
+                objectParam: {
+                  type: 'object',
+                  properties: {
+                    nested: { type: 'string' },
+                  },
+                },
+              },
+              required: ['stringParam'],
+            },
+          },
+        ],
+      });
+
+      const call = mockGenerateContentStream.mock.calls[0][0];
+      const functionDeclaration = call.tools[0].functionDeclarations[0];
+
+      // Verify all types converted to Google SchemaType
+      expect(functionDeclaration.parameters.properties.stringParam.type).toBe('STRING');
+      expect(functionDeclaration.parameters.properties.numberParam.type).toBe('NUMBER');
+      expect(functionDeclaration.parameters.properties.integerParam.type).toBe('INTEGER');
+      expect(functionDeclaration.parameters.properties.booleanParam.type).toBe('BOOLEAN');
+      expect(functionDeclaration.parameters.properties.arrayParam.type).toBe('ARRAY');
+      expect(functionDeclaration.parameters.properties.objectParam.type).toBe('OBJECT');
+    });
+  });
+});

--- a/apps/server/src/services/chat-providers/__tests__/moonshot.test.ts
+++ b/apps/server/src/services/chat-providers/__tests__/moonshot.test.ts
@@ -1,8 +1,9 @@
 /**
- * OpenAI Chat Provider Tests
+ * Moonshot (Kimi) Chat Provider Tests
  *
- * Phase 16B: Unit tests for OpenAIChatProvider
+ * Phase 16D: Unit tests for MoonshotChatProvider
  * Tests the manual 10-turn tool execution loop and API integration.
+ * Uses OpenAI-compatible API with thinking mode support.
  */
 
 import type { Pool } from 'pg';
@@ -78,10 +79,10 @@ function createMockToolExecutors() {
 }
 
 /**
- * Create a mock streaming response for OpenAI
+ * Create a mock OpenAI streaming response
  * Returns an async generator that yields streaming chunks
  */
-function createMockOpenAIResponse(options: {
+function createMockOpenAIStreamResponse(options: {
   content?: string | null;
   toolCalls?: Array<{
     id: string;
@@ -94,51 +95,26 @@ function createMockOpenAIResponse(options: {
   totalTokens?: number;
   model?: string;
 }) {
-  // Create streaming response chunks
-  const chunks: Array<{
-    id: string;
-    object: string;
-    created: number;
-    model: string;
-    choices: Array<{
-      index: number;
-      delta: {
-        role?: string;
-        content?: string | null;
-        tool_calls?: Array<{
-          index: number;
-          id?: string;
-          type?: string;
-          function?: { name?: string; arguments?: string };
-        }>;
-      };
-      finish_reason: string | null;
-    }>;
-    usage?: {
-      prompt_tokens: number;
-      completion_tokens: number;
-      total_tokens: number;
-    };
-  }> = [];
+  const chunks: unknown[] = [];
 
-  // If there's content, stream it
+  // If we have content, create text chunks
   if (options.content) {
     chunks.push({
       id: 'chatcmpl-test',
       object: 'chat.completion.chunk',
       created: Date.now(),
-      model: options.model ?? 'gpt-4o',
+      model: options.model ?? 'kimi-k2-0905-preview',
       choices: [
         {
           index: 0,
-          delta: { role: 'assistant', content: options.content },
+          delta: { content: options.content },
           finish_reason: null,
         },
       ],
     });
   }
 
-  // If there are tool calls, stream them
+  // If we have tool calls, create tool call chunks
   if (options.toolCalls) {
     for (let i = 0; i < options.toolCalls.length; i++) {
       const tc = options.toolCalls[i];
@@ -146,7 +122,7 @@ function createMockOpenAIResponse(options: {
         id: 'chatcmpl-test',
         object: 'chat.completion.chunk',
         created: Date.now(),
-        model: options.model ?? 'gpt-4o',
+        model: options.model ?? 'kimi-k2-0905-preview',
         choices: [
           {
             index: 0,
@@ -156,7 +132,10 @@ function createMockOpenAIResponse(options: {
                   index: i,
                   id: tc.id,
                   type: 'function',
-                  function: { name: tc.function.name, arguments: tc.function.arguments },
+                  function: {
+                    name: tc.function.name,
+                    arguments: tc.function.arguments,
+                  },
                 },
               ],
             },
@@ -172,7 +151,7 @@ function createMockOpenAIResponse(options: {
     id: 'chatcmpl-test',
     object: 'chat.completion.chunk',
     created: Date.now(),
-    model: options.model ?? 'gpt-4o',
+    model: options.model ?? 'kimi-k2-0905-preview',
     choices: [
       {
         index: 0,
@@ -187,7 +166,7 @@ function createMockOpenAIResponse(options: {
     },
   });
 
-  // Return an async iterator (mimics OpenAI streaming response)
+  // Return async generator
   return (async function* () {
     for (const chunk of chunks) {
       yield chunk;
@@ -199,10 +178,10 @@ function createMockOpenAIResponse(options: {
 // Tests
 // =============================================================================
 
-let OpenAIChatProvider: typeof import('../openai.js')['OpenAIChatProvider'];
-let createOpenAIProvider: typeof import('../openai.js')['createOpenAIProvider'];
+let MoonshotChatProvider: typeof import('../moonshot.js')['MoonshotChatProvider'];
+let createMoonshotProvider: typeof import('../moonshot.js')['createMoonshotProvider'];
 
-describe('OpenAIChatProvider', () => {
+describe('MoonshotChatProvider', () => {
   const mockPool = createMockPool();
   const mockContext = { collectionId: '11111111-1111-4111-8111-111111111111' };
 
@@ -210,7 +189,7 @@ describe('OpenAIChatProvider', () => {
     vi.clearAllMocks();
 
     // Default API key configured
-    mockGetProviderApiKey.mockResolvedValue('test-openai-key');
+    mockGetProviderApiKey.mockResolvedValue('test-moonshot-key');
 
     // Default tool executors
     const mockExecutors = createMockToolExecutors();
@@ -220,9 +199,9 @@ describe('OpenAIChatProvider', () => {
     });
 
     // Import after mocks are set up
-    const module = await import('../openai.js');
-    OpenAIChatProvider = module.OpenAIChatProvider;
-    createOpenAIProvider = module.createOpenAIProvider;
+    const module = await import('../moonshot.js');
+    MoonshotChatProvider = module.MoonshotChatProvider;
+    createMoonshotProvider = module.createMoonshotProvider;
   });
 
   afterEach(() => {
@@ -235,17 +214,17 @@ describe('OpenAIChatProvider', () => {
 
   describe('provider properties', () => {
     it('should have correct name', () => {
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
-      expect(provider.name).toBe('openai');
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
+      expect(provider.name).toBe('moonshot');
     });
 
     it('should have correct capabilities', () => {
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       expect(provider.capabilities).toEqual({
         supportsTools: true,
         supportsStreaming: true,
-        supportsVision: true,
-        maxContextTokens: 128000,
+        supportsVision: false,
+        maxContextTokens: 256000,
       });
     });
   });
@@ -253,17 +232,17 @@ describe('OpenAIChatProvider', () => {
   describe('isConfigured', () => {
     it('should return true when API key is configured', async () => {
       mockGetProviderApiKey.mockResolvedValue('test-api-key');
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
 
       const result = await provider.isConfigured();
 
       expect(result).toBe(true);
-      expect(mockGetProviderApiKey).toHaveBeenCalledWith(mockPool, 'openai');
+      expect(mockGetProviderApiKey).toHaveBeenCalledWith(mockPool, 'moonshot');
     });
 
     it('should return false when API key is not configured', async () => {
       mockGetProviderApiKey.mockResolvedValue(null);
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
 
       const result = await provider.isConfigured();
 
@@ -278,7 +257,7 @@ describe('OpenAIChatProvider', () => {
   describe('chat without tools', () => {
     it('should complete successfully with simple text response', async () => {
       mockChatCompletionsCreate.mockResolvedValue(
-        createMockOpenAIResponse({
+        createMockOpenAIStreamResponse({
           content: 'Hello! How can I help you today?',
           finishReason: 'stop',
           promptTokens: 50,
@@ -287,10 +266,10 @@ describe('OpenAIChatProvider', () => {
         })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Hello' }],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
       });
 
       expect(result.content).toBe('Hello! How can I help you today?');
@@ -301,21 +280,21 @@ describe('OpenAIChatProvider', () => {
         outputTokens: 15,
         totalTokens: 65,
       });
-      expect(result.model).toBe('gpt-4o');
-      expect(result.provider).toBe('openai');
+      expect(result.model).toBe('kimi-k2-0905-preview');
+      expect(result.provider).toBe('moonshot');
     });
 
     it('should handle system prompt correctly', async () => {
       mockChatCompletionsCreate.mockResolvedValue(
-        createMockOpenAIResponse({
+        createMockOpenAIStreamResponse({
           content: 'I am a helpful assistant.',
         })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       await provider.chat({
         messages: [{ role: 'user', content: 'Who are you?' }],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
         systemPrompt: 'You are a helpful assistant.',
       });
 
@@ -330,13 +309,13 @@ describe('OpenAIChatProvider', () => {
 
     it('should pass optional parameters correctly', async () => {
       mockChatCompletionsCreate.mockResolvedValue(
-        createMockOpenAIResponse({ content: 'Response' })
+        createMockOpenAIStreamResponse({ content: 'Response' })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
         maxTokens: 1000,
         temperature: 0.7,
         stopSequences: ['END'],
@@ -344,7 +323,7 @@ describe('OpenAIChatProvider', () => {
 
       expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'gpt-4o',
+          model: 'kimi-k2-0905-preview',
           max_tokens: 1000,
           temperature: 0.7,
           stop: ['END'],
@@ -354,16 +333,16 @@ describe('OpenAIChatProvider', () => {
 
     it('should handle empty content response', async () => {
       mockChatCompletionsCreate.mockResolvedValue(
-        createMockOpenAIResponse({
+        createMockOpenAIStreamResponse({
           content: null,
           finishReason: 'stop',
         })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
       });
 
       expect(result.content).toBe('');
@@ -402,7 +381,7 @@ describe('OpenAIChatProvider', () => {
       // First call: model wants to use a tool
       mockChatCompletionsCreate
         .mockResolvedValueOnce(
-          createMockOpenAIResponse({
+          createMockOpenAIStreamResponse({
             content: null,
             toolCalls: [
               {
@@ -419,16 +398,16 @@ describe('OpenAIChatProvider', () => {
         )
         // Second call: model returns final response after tool execution
         .mockResolvedValueOnce(
-          createMockOpenAIResponse({
+          createMockOpenAIStreamResponse({
             content: 'Based on the search results, I found relevant information.',
             finishReason: 'stop',
           })
         );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Search for test query' }],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
         tools: mockTools,
       });
 
@@ -447,7 +426,7 @@ describe('OpenAIChatProvider', () => {
       // First call: model wants to use multiple tools
       mockChatCompletionsCreate
         .mockResolvedValueOnce(
-          createMockOpenAIResponse({
+          createMockOpenAIStreamResponse({
             content: null,
             toolCalls: [
               {
@@ -471,16 +450,16 @@ describe('OpenAIChatProvider', () => {
           })
         )
         .mockResolvedValueOnce(
-          createMockOpenAIResponse({
+          createMockOpenAIStreamResponse({
             content: 'Completed both searches.',
             finishReason: 'stop',
           })
         );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Search and list docs' }],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
         tools: mockTools,
       });
 
@@ -499,7 +478,7 @@ describe('OpenAIChatProvider', () => {
       // Turn 1: First tool call
       mockChatCompletionsCreate
         .mockResolvedValueOnce(
-          createMockOpenAIResponse({
+          createMockOpenAIStreamResponse({
             content: null,
             toolCalls: [
               {
@@ -516,7 +495,7 @@ describe('OpenAIChatProvider', () => {
         )
         // Turn 2: Second tool call based on first results
         .mockResolvedValueOnce(
-          createMockOpenAIResponse({
+          createMockOpenAIStreamResponse({
             content: null,
             toolCalls: [
               {
@@ -533,16 +512,16 @@ describe('OpenAIChatProvider', () => {
         )
         // Turn 3: Final response
         .mockResolvedValueOnce(
-          createMockOpenAIResponse({
+          createMockOpenAIStreamResponse({
             content: 'After multiple tool calls, here is the answer.',
             finishReason: 'stop',
           })
         );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Complex query' }],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
         tools: mockTools,
       });
 
@@ -554,16 +533,16 @@ describe('OpenAIChatProvider', () => {
 
     it('should convert tools to OpenAI function format', async () => {
       mockChatCompletionsCreate.mockResolvedValue(
-        createMockOpenAIResponse({
+        createMockOpenAIStreamResponse({
           content: 'Response',
           finishReason: 'stop',
         })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
         tools: mockTools,
       });
 
@@ -595,35 +574,41 @@ describe('OpenAIChatProvider', () => {
   // ===========================================================================
 
   describe('max turns limit', () => {
-    it('should complete with end_turn when max turns (10) is reached', async () => {
+    it('should stop after max turns (10) is reached', async () => {
       const toolExecutors = createMockToolExecutors();
       mockBuildAgentTools.mockReturnValue({
         tools: [],
         toolExecutors,
       });
 
-      // Always return tool calls to trigger max turns
-      mockChatCompletionsCreate.mockImplementation(() =>
-        createMockOpenAIResponse({
+      // Create a counter to generate unique IDs for each call
+      let callCount = 0;
+
+      // Always return tool calls to trigger infinite loop
+      // Use mockImplementation to generate a new stream each time
+      mockChatCompletionsCreate.mockImplementation(async () => {
+        callCount++;
+        return createMockOpenAIStreamResponse({
           content: null,
           toolCalls: [
             {
-              id: 'call-loop',
+              id: `call-loop-${callCount}`,
               type: 'function',
               function: {
                 name: 'search_rag',
-                arguments: JSON.stringify({ query: 'loop' }),
+                arguments: JSON.stringify({ query: `loop-${callCount}` }),
               },
             },
           ],
           finishReason: 'tool_calls',
-        })
-      );
+        });
+      });
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
+
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Trigger loop' }],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
         tools: [
           {
             name: 'search_rag',
@@ -636,9 +621,9 @@ describe('OpenAIChatProvider', () => {
         ],
       });
 
-      // Should complete gracefully with end_turn (not throw)
+      // Should stop with end_turn after max turns
       expect(result.stopReason).toBe('end_turn');
-      // Should have called 10 times (max turns)
+      // Should have called 10 times
       expect(mockChatCompletionsCreate).toHaveBeenCalledTimes(10);
     });
   });
@@ -651,44 +636,35 @@ describe('OpenAIChatProvider', () => {
     it('should throw error when API key is not configured', async () => {
       mockGetProviderApiKey.mockResolvedValue(null);
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
 
       await expect(
         provider.chat({
           messages: [{ role: 'user', content: 'Test' }],
-          model: 'gpt-4o',
+          model: 'kimi-k2-0905-preview',
         })
-      ).rejects.toThrow('OpenAI API key not configured');
+      ).rejects.toThrow('Moonshot API key not configured');
     });
 
-    it('should handle empty stream gracefully', async () => {
-      // Return an empty stream with just a finish chunk
-      mockChatCompletionsCreate.mockImplementation(() =>
+    it('should handle response with no choices gracefully', async () => {
+      // Return a stream with empty choices array - should just return empty response
+      mockChatCompletionsCreate.mockResolvedValue(
         (async function* () {
           yield {
             id: 'chatcmpl-test',
-            object: 'chat.completion.chunk',
-            created: Date.now(),
-            model: 'gpt-4o',
-            choices: [
-              {
-                index: 0,
-                delta: {},
-                finish_reason: 'stop',
-              },
-            ],
+            choices: [], // No choices
             usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
           };
         })()
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
       });
 
-      // Should complete with empty content
+      // Should return empty content with end_turn
       expect(result.content).toBe('');
       expect(result.stopReason).toBe('end_turn');
     });
@@ -704,7 +680,7 @@ describe('OpenAIChatProvider', () => {
       // First call: tool call that will fail
       mockChatCompletionsCreate
         .mockResolvedValueOnce(
-          createMockOpenAIResponse({
+          createMockOpenAIStreamResponse({
             content: null,
             toolCalls: [
               {
@@ -721,16 +697,16 @@ describe('OpenAIChatProvider', () => {
         )
         // Second call: model handles error and responds
         .mockResolvedValueOnce(
-          createMockOpenAIResponse({
+          createMockOpenAIStreamResponse({
             content: 'I encountered an error with the search tool.',
             finishReason: 'stop',
           })
         );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Search' }],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
         tools: [
           {
             name: 'search_rag',
@@ -760,7 +736,7 @@ describe('OpenAIChatProvider', () => {
 
       mockChatCompletionsCreate
         .mockResolvedValueOnce(
-          createMockOpenAIResponse({
+          createMockOpenAIStreamResponse({
             content: null,
             toolCalls: [
               {
@@ -776,16 +752,16 @@ describe('OpenAIChatProvider', () => {
           })
         )
         .mockResolvedValueOnce(
-          createMockOpenAIResponse({
+          createMockOpenAIStreamResponse({
             content: 'I do not recognize that tool.',
             finishReason: 'stop',
           })
         );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Use unknown tool' }],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
         tools: [
           {
             name: 'unknown_tool',
@@ -814,7 +790,7 @@ describe('OpenAIChatProvider', () => {
 
       mockChatCompletionsCreate
         .mockResolvedValueOnce(
-          createMockOpenAIResponse({
+          createMockOpenAIStreamResponse({
             content: null,
             toolCalls: [
               {
@@ -830,16 +806,16 @@ describe('OpenAIChatProvider', () => {
           })
         )
         .mockResolvedValueOnce(
-          createMockOpenAIResponse({
+          createMockOpenAIStreamResponse({
             content: 'Handled error.',
             finishReason: 'stop',
           })
         );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
         tools: [
           {
             name: 'search_rag',
@@ -865,18 +841,18 @@ describe('OpenAIChatProvider', () => {
 
   describe('stop reason mapping', () => {
     it('should map "stop" to "end_turn"', async () => {
-      // OpenAI's 'stop' indicates natural completion, mapped to 'end_turn' for consistency
+      // Moonshot's 'stop' indicates natural completion, mapped to 'end_turn' for consistency
       mockChatCompletionsCreate.mockResolvedValue(
-        createMockOpenAIResponse({
+        createMockOpenAIStreamResponse({
           content: 'Response',
           finishReason: 'stop',
         })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
       });
 
       expect(result.stopReason).toBe('end_turn');
@@ -884,16 +860,16 @@ describe('OpenAIChatProvider', () => {
 
     it('should map "length" to "max_tokens"', async () => {
       mockChatCompletionsCreate.mockResolvedValue(
-        createMockOpenAIResponse({
+        createMockOpenAIStreamResponse({
           content: 'Truncated response...',
           finishReason: 'length',
         })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
       });
 
       expect(result.stopReason).toBe('max_tokens');
@@ -901,16 +877,16 @@ describe('OpenAIChatProvider', () => {
 
     it('should map unknown reason to "end_turn"', async () => {
       mockChatCompletionsCreate.mockResolvedValue(
-        createMockOpenAIResponse({
+        createMockOpenAIStreamResponse({
           content: 'Response',
           finishReason: 'unknown_reason',
         })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
       });
 
       expect(result.stopReason).toBe('end_turn');
@@ -921,12 +897,12 @@ describe('OpenAIChatProvider', () => {
   // Factory Function Tests
   // ===========================================================================
 
-  describe('createOpenAIProvider factory', () => {
-    it('should create an OpenAIChatProvider instance', () => {
-      const provider = createOpenAIProvider(mockPool, mockContext);
+  describe('createMoonshotProvider factory', () => {
+    it('should create a MoonshotChatProvider instance', () => {
+      const provider = createMoonshotProvider(mockPool, mockContext);
 
-      expect(provider).toBeInstanceOf(OpenAIChatProvider);
-      expect(provider.name).toBe('openai');
+      expect(provider).toBeInstanceOf(MoonshotChatProvider);
+      expect(provider.name).toBe('moonshot');
     });
   });
 
@@ -937,17 +913,17 @@ describe('OpenAIChatProvider', () => {
   describe('message conversion', () => {
     it('should convert user messages correctly', async () => {
       mockChatCompletionsCreate.mockResolvedValue(
-        createMockOpenAIResponse({ content: 'Response' })
+        createMockOpenAIStreamResponse({ content: 'Response' })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       await provider.chat({
         messages: [
           { role: 'user', content: 'First message' },
           { role: 'assistant', content: 'First response' },
           { role: 'user', content: 'Second message' },
         ],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
       });
 
       expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
@@ -969,7 +945,7 @@ describe('OpenAIChatProvider', () => {
   describe('usage tracking', () => {
     it('should track token usage correctly', async () => {
       mockChatCompletionsCreate.mockResolvedValue(
-        createMockOpenAIResponse({
+        createMockOpenAIStreamResponse({
           content: 'Response',
           promptTokens: 200,
           completionTokens: 100,
@@ -977,10 +953,10 @@ describe('OpenAIChatProvider', () => {
         })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
       });
 
       expect(result.usage).toEqual({
@@ -991,14 +967,12 @@ describe('OpenAIChatProvider', () => {
     });
 
     it('should handle missing usage data', async () => {
-      // Stream without usage data in final chunk
-      mockChatCompletionsCreate.mockImplementation(() =>
+      // Create stream without usage data
+      mockChatCompletionsCreate.mockResolvedValue(
         (async function* () {
+          // Content chunk
           yield {
             id: 'chatcmpl-test',
-            object: 'chat.completion.chunk',
-            created: Date.now(),
-            model: 'gpt-4o',
             choices: [
               {
                 index: 0,
@@ -1007,11 +981,9 @@ describe('OpenAIChatProvider', () => {
               },
             ],
           };
+          // Final chunk with no usage
           yield {
             id: 'chatcmpl-test',
-            object: 'chat.completion.chunk',
-            created: Date.now(),
-            model: 'gpt-4o',
             choices: [
               {
                 index: 0,
@@ -1024,16 +996,146 @@ describe('OpenAIChatProvider', () => {
         })()
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'kimi-k2-0905-preview',
       });
 
       expect(result.usage).toEqual({
         inputTokens: 0,
         outputTokens: 0,
         totalTokens: 0,
+      });
+    });
+  });
+
+  // ===========================================================================
+  // Thinking Mode Tests
+  // ===========================================================================
+
+  describe('thinking mode', () => {
+    it('should enable thinking mode for kimi-k2-thinking models', async () => {
+      mockChatCompletionsCreate.mockResolvedValue(
+        createMockOpenAIStreamResponse({
+          content: 'Thoughtful response',
+          model: 'kimi-k2-thinking',
+        })
+      );
+
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
+      await provider.chat({
+        messages: [{ role: 'user', content: 'Test' }],
+        model: 'kimi-k2-thinking',
+      });
+
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'kimi-k2-thinking',
+          extra_body: {
+            thinking: { type: 'enabled', max_tokens: 4096 },
+          },
+        })
+      );
+    });
+
+    it('should enable thinking mode for kimi-k2-thinking-turbo models', async () => {
+      mockChatCompletionsCreate.mockResolvedValue(
+        createMockOpenAIStreamResponse({
+          content: 'Thoughtful response',
+          model: 'kimi-k2-thinking-turbo',
+        })
+      );
+
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
+      await provider.chat({
+        messages: [{ role: 'user', content: 'Test' }],
+        model: 'kimi-k2-thinking-turbo',
+      });
+
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'kimi-k2-thinking-turbo',
+          extra_body: {
+            thinking: { type: 'enabled', max_tokens: 4096 },
+          },
+        })
+      );
+    });
+
+    it('should not enable thinking mode for non-thinking models', async () => {
+      mockChatCompletionsCreate.mockResolvedValue(
+        createMockOpenAIStreamResponse({
+          content: 'Response',
+        })
+      );
+
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
+      await provider.chat({
+        messages: [{ role: 'user', content: 'Test' }],
+        model: 'kimi-k2-0905-preview',
+      });
+
+      // Verify extra_body is not included
+      const call = mockChatCompletionsCreate.mock.calls[0][0];
+      expect(call.extra_body).toBeUndefined();
+    });
+
+    it('should handle thinking mode in tool execution flow', async () => {
+      const toolExecutors = createMockToolExecutors();
+      mockBuildAgentTools.mockReturnValue({
+        tools: [],
+        toolExecutors,
+      });
+
+      // First call with tool use
+      mockChatCompletionsCreate
+        .mockResolvedValueOnce(
+          createMockOpenAIStreamResponse({
+            content: null,
+            toolCalls: [
+              {
+                id: 'call-1',
+                type: 'function',
+                function: {
+                  name: 'search_rag',
+                  arguments: JSON.stringify({ query: 'test' }),
+                },
+              },
+            ],
+            finishReason: 'tool_calls',
+          })
+        )
+        .mockResolvedValueOnce(
+          createMockOpenAIStreamResponse({
+            content: 'Final thoughtful response',
+            finishReason: 'stop',
+          })
+        );
+
+      const provider = new MoonshotChatProvider(mockPool, mockContext);
+      await provider.chat({
+        messages: [{ role: 'user', content: 'Complex question' }],
+        model: 'kimi-k2-thinking',
+        tools: [
+          {
+            name: 'search_rag',
+            description: 'Search',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+      });
+
+      // Verify both calls have extra_body for thinking mode
+      expect(mockChatCompletionsCreate).toHaveBeenCalledTimes(2);
+      const firstCall = mockChatCompletionsCreate.mock.calls[0][0];
+      const secondCall = mockChatCompletionsCreate.mock.calls[1][0];
+
+      expect(firstCall.extra_body).toEqual({
+        thinking: { type: 'enabled', max_tokens: 4096 },
+      });
+      expect(secondCall.extra_body).toEqual({
+        thinking: { type: 'enabled', max_tokens: 4096 },
       });
     });
   });

--- a/apps/server/src/services/chat-providers/__tests__/ollama.test.ts
+++ b/apps/server/src/services/chat-providers/__tests__/ollama.test.ts
@@ -36,6 +36,40 @@ function createMockContext(): ToolContext {
   };
 }
 
+/**
+ * Create a mock streaming response for Ollama
+ * Returns an async generator that yields streaming chunks
+ */
+function createMockOllamaStreamResponse(options: {
+  content?: string;
+  promptEvalCount?: number;
+  evalCount?: number;
+}) {
+  return (async function* () {
+    // Yield content chunk
+    if (options.content) {
+      yield {
+        message: {
+          role: 'assistant',
+          content: options.content,
+        },
+        done: false,
+      };
+    }
+
+    // Yield final chunk with token counts
+    yield {
+      message: {
+        role: 'assistant',
+        content: '',
+      },
+      done: true,
+      prompt_eval_count: options.promptEvalCount ?? 0,
+      eval_count: options.evalCount ?? 0,
+    };
+  })();
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -104,15 +138,13 @@ describe('OllamaChatProvider', () => {
 
   describe('chat', () => {
     it('should send chat with simple message and return normalized response', async () => {
-      chatMock.mockResolvedValue({
-        message: {
-          role: 'assistant',
+      chatMock.mockImplementation(() =>
+        createMockOllamaStreamResponse({
           content: 'Hello! How can I help you today?',
-        },
-        done: true,
-        prompt_eval_count: 15,
-        eval_count: 10,
-      });
+          promptEvalCount: 15,
+          evalCount: 10,
+        })
+      );
 
       const db = createMockPool();
       const context = createMockContext();
@@ -128,7 +160,7 @@ describe('OllamaChatProvider', () => {
       expect(chatMock).toHaveBeenCalledWith({
         model: 'llama3.2:3b',
         messages: [{ role: 'user', content: 'Hello' }],
-        stream: false,
+        stream: true,
         options: {
           temperature: undefined,
           num_predict: undefined,
@@ -149,15 +181,13 @@ describe('OllamaChatProvider', () => {
     });
 
     it('should include system prompt as first message', async () => {
-      chatMock.mockResolvedValue({
-        message: {
-          role: 'assistant',
+      chatMock.mockImplementation(() =>
+        createMockOllamaStreamResponse({
           content: 'I am a helpful assistant.',
-        },
-        done: true,
-        prompt_eval_count: 30,
-        eval_count: 8,
-      });
+          promptEvalCount: 30,
+          evalCount: 8,
+        })
+      );
 
       const db = createMockPool();
       const context = createMockContext();
@@ -182,15 +212,13 @@ describe('OllamaChatProvider', () => {
     });
 
     it('should handle conversation history with multiple messages', async () => {
-      chatMock.mockResolvedValue({
-        message: {
-          role: 'assistant',
+      chatMock.mockImplementation(() =>
+        createMockOllamaStreamResponse({
           content: 'The answer is 4.',
-        },
-        done: true,
-        prompt_eval_count: 50,
-        eval_count: 6,
-      });
+          promptEvalCount: 50,
+          evalCount: 6,
+        })
+      );
 
       const db = createMockPool();
       const context = createMockContext();
@@ -219,15 +247,13 @@ describe('OllamaChatProvider', () => {
     });
 
     it('should extract text from complex content blocks', async () => {
-      chatMock.mockResolvedValue({
-        message: {
-          role: 'assistant',
+      chatMock.mockImplementation(() =>
+        createMockOllamaStreamResponse({
           content: 'I received your text messages.',
-        },
-        done: true,
-        prompt_eval_count: 40,
-        eval_count: 8,
-      });
+          promptEvalCount: 40,
+          evalCount: 8,
+        })
+      );
 
       const db = createMockPool();
       const context = createMockContext();
@@ -258,13 +284,11 @@ describe('OllamaChatProvider', () => {
     });
 
     it('should skip system messages in the messages array', async () => {
-      chatMock.mockResolvedValue({
-        message: {
-          role: 'assistant',
+      chatMock.mockImplementation(() =>
+        createMockOllamaStreamResponse({
           content: 'Response.',
-        },
-        done: true,
-      });
+        })
+      );
 
       const db = createMockPool();
       const context = createMockContext();
@@ -292,13 +316,11 @@ describe('OllamaChatProvider', () => {
     });
 
     it('should pass optional parameters to Ollama', async () => {
-      chatMock.mockResolvedValue({
-        message: {
-          role: 'assistant',
+      chatMock.mockImplementation(() =>
+        createMockOllamaStreamResponse({
           content: 'Done.',
-        },
-        done: true,
-      });
+        })
+      );
 
       const db = createMockPool();
       const context = createMockContext();
@@ -317,7 +339,7 @@ describe('OllamaChatProvider', () => {
       expect(chatMock).toHaveBeenCalledWith({
         model: 'llama3.2:3b',
         messages: [{ role: 'user', content: 'Test' }],
-        stream: false,
+        stream: true,
         options: {
           temperature: 0.7,
           num_predict: 500,
@@ -327,14 +349,12 @@ describe('OllamaChatProvider', () => {
     });
 
     it('should handle response without token counts', async () => {
-      chatMock.mockResolvedValue({
-        message: {
-          role: 'assistant',
+      chatMock.mockImplementation(() =>
+        createMockOllamaStreamResponse({
           content: 'Response without counts.',
-        },
-        done: true,
-        // No prompt_eval_count or eval_count
-      });
+          // No promptEvalCount or evalCount (defaults to 0)
+        })
+      );
 
       const db = createMockPool();
       const context = createMockContext();
@@ -354,14 +374,13 @@ describe('OllamaChatProvider', () => {
       });
     });
 
-    it('should throw error when response has no message content', async () => {
-      chatMock.mockResolvedValue({
-        message: {
-          role: 'assistant',
-          // content is undefined
-        },
-        done: true,
-      });
+    it('should handle empty content response', async () => {
+      // Stream with only final chunk (no content)
+      chatMock.mockImplementation(() =>
+        createMockOllamaStreamResponse({
+          content: '',
+        })
+      );
 
       const db = createMockPool();
       const context = createMockContext();
@@ -372,10 +391,9 @@ describe('OllamaChatProvider', () => {
         model: 'llama3.2:3b',
       };
 
-      await expect(provider.chat(params)).rejects.toThrow('Ollama chat failed:');
-      await expect(provider.chat(params)).rejects.toThrow(
-        'Ollama response missing message content'
-      );
+      const response = await provider.chat(params);
+      expect(response.content).toBe('');
+      expect(response.stopReason).toBe('end_turn');
     });
 
     it('should wrap Ollama SDK errors with context', async () => {
@@ -390,7 +408,9 @@ describe('OllamaChatProvider', () => {
         model: 'llama3.2:3b',
       };
 
-      await expect(provider.chat(params)).rejects.toThrow('Ollama chat failed: Connection refused');
+      await expect(provider.chat(params)).rejects.toThrow(
+        'Ollama streaming chat failed: Connection refused'
+      );
     });
 
     it('should handle non-Error thrown values', async () => {
@@ -405,7 +425,9 @@ describe('OllamaChatProvider', () => {
         model: 'llama3.2:3b',
       };
 
-      await expect(provider.chat(params)).rejects.toThrow('Ollama chat failed: String error');
+      await expect(provider.chat(params)).rejects.toThrow(
+        'Ollama streaming chat failed: String error'
+      );
     });
   });
 

--- a/apps/server/src/services/chat-providers/__tests__/zhipu.test.ts
+++ b/apps/server/src/services/chat-providers/__tests__/zhipu.test.ts
@@ -1,8 +1,8 @@
 /**
- * OpenAI Chat Provider Tests
+ * Z.AI (Zhipu) Chat Provider Tests
  *
- * Phase 16B: Unit tests for OpenAIChatProvider
- * Tests the manual 10-turn tool execution loop and API integration.
+ * Phase 16B: Unit tests for ZhipuChatProvider
+ * Tests the manual 10-turn tool execution loop and OpenAI-compatible API integration.
  */
 
 import type { Pool } from 'pg';
@@ -77,10 +77,6 @@ function createMockToolExecutors() {
   };
 }
 
-/**
- * Create a mock streaming response for OpenAI
- * Returns an async generator that yields streaming chunks
- */
 function createMockOpenAIResponse(options: {
   content?: string | null;
   toolCalls?: Array<{
@@ -104,7 +100,7 @@ function createMockOpenAIResponse(options: {
       index: number;
       delta: {
         role?: string;
-        content?: string | null;
+        content?: string;
         tool_calls?: Array<{
           index: number;
           id?: string;
@@ -127,7 +123,7 @@ function createMockOpenAIResponse(options: {
       id: 'chatcmpl-test',
       object: 'chat.completion.chunk',
       created: Date.now(),
-      model: options.model ?? 'gpt-4o',
+      model: options.model ?? 'glm-4.6',
       choices: [
         {
           index: 0,
@@ -146,7 +142,7 @@ function createMockOpenAIResponse(options: {
         id: 'chatcmpl-test',
         object: 'chat.completion.chunk',
         created: Date.now(),
-        model: options.model ?? 'gpt-4o',
+        model: options.model ?? 'glm-4.6',
         choices: [
           {
             index: 0,
@@ -172,7 +168,7 @@ function createMockOpenAIResponse(options: {
     id: 'chatcmpl-test',
     object: 'chat.completion.chunk',
     created: Date.now(),
-    model: options.model ?? 'gpt-4o',
+    model: options.model ?? 'glm-4.6',
     choices: [
       {
         index: 0,
@@ -187,7 +183,7 @@ function createMockOpenAIResponse(options: {
     },
   });
 
-  // Return an async iterator (mimics OpenAI streaming response)
+  // Return an async iterator
   return (async function* () {
     for (const chunk of chunks) {
       yield chunk;
@@ -199,10 +195,11 @@ function createMockOpenAIResponse(options: {
 // Tests
 // =============================================================================
 
-let OpenAIChatProvider: typeof import('../openai.js')['OpenAIChatProvider'];
-let createOpenAIProvider: typeof import('../openai.js')['createOpenAIProvider'];
+let ZhipuChatProvider: typeof import('../zhipu.js')['ZhipuChatProvider'];
+let createZhipuProvider: typeof import('../zhipu.js')['createZhipuProvider'];
+let OpenAI: typeof import('openai').default;
 
-describe('OpenAIChatProvider', () => {
+describe('ZhipuChatProvider', () => {
   const mockPool = createMockPool();
   const mockContext = { collectionId: '11111111-1111-4111-8111-111111111111' };
 
@@ -210,7 +207,7 @@ describe('OpenAIChatProvider', () => {
     vi.clearAllMocks();
 
     // Default API key configured
-    mockGetProviderApiKey.mockResolvedValue('test-openai-key');
+    mockGetProviderApiKey.mockResolvedValue('test-zhipu-key');
 
     // Default tool executors
     const mockExecutors = createMockToolExecutors();
@@ -220,9 +217,12 @@ describe('OpenAIChatProvider', () => {
     });
 
     // Import after mocks are set up
-    const module = await import('../openai.js');
-    OpenAIChatProvider = module.OpenAIChatProvider;
-    createOpenAIProvider = module.createOpenAIProvider;
+    const module = await import('../zhipu.js');
+    ZhipuChatProvider = module.ZhipuChatProvider;
+    createZhipuProvider = module.createZhipuProvider;
+
+    const openaiModule = await import('openai');
+    OpenAI = openaiModule.default;
   });
 
   afterEach(() => {
@@ -235,16 +235,16 @@ describe('OpenAIChatProvider', () => {
 
   describe('provider properties', () => {
     it('should have correct name', () => {
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
-      expect(provider.name).toBe('openai');
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
+      expect(provider.name).toBe('zhipu');
     });
 
     it('should have correct capabilities', () => {
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
       expect(provider.capabilities).toEqual({
         supportsTools: true,
         supportsStreaming: true,
-        supportsVision: true,
+        supportsVision: false,
         maxContextTokens: 128000,
       });
     });
@@ -253,17 +253,17 @@ describe('OpenAIChatProvider', () => {
   describe('isConfigured', () => {
     it('should return true when API key is configured', async () => {
       mockGetProviderApiKey.mockResolvedValue('test-api-key');
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
 
       const result = await provider.isConfigured();
 
       expect(result).toBe(true);
-      expect(mockGetProviderApiKey).toHaveBeenCalledWith(mockPool, 'openai');
+      expect(mockGetProviderApiKey).toHaveBeenCalledWith(mockPool, 'zhipu');
     });
 
     it('should return false when API key is not configured', async () => {
       mockGetProviderApiKey.mockResolvedValue(null);
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
 
       const result = await provider.isConfigured();
 
@@ -287,10 +287,10 @@ describe('OpenAIChatProvider', () => {
         })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Hello' }],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
       });
 
       expect(result.content).toBe('Hello! How can I help you today?');
@@ -301,8 +301,8 @@ describe('OpenAIChatProvider', () => {
         outputTokens: 15,
         totalTokens: 65,
       });
-      expect(result.model).toBe('gpt-4o');
-      expect(result.provider).toBe('openai');
+      expect(result.model).toBe('glm-4.6');
+      expect(result.provider).toBe('zhipu');
     });
 
     it('should handle system prompt correctly', async () => {
@@ -312,10 +312,10 @@ describe('OpenAIChatProvider', () => {
         })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
       await provider.chat({
         messages: [{ role: 'user', content: 'Who are you?' }],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
         systemPrompt: 'You are a helpful assistant.',
       });
 
@@ -333,10 +333,10 @@ describe('OpenAIChatProvider', () => {
         createMockOpenAIResponse({ content: 'Response' })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
       await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
         maxTokens: 1000,
         temperature: 0.7,
         stopSequences: ['END'],
@@ -344,7 +344,7 @@ describe('OpenAIChatProvider', () => {
 
       expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'gpt-4o',
+          model: 'glm-4.6',
           max_tokens: 1000,
           temperature: 0.7,
           stop: ['END'],
@@ -360,13 +360,30 @@ describe('OpenAIChatProvider', () => {
         })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
       });
 
       expect(result.content).toBe('');
+    });
+
+    it('should create OpenAI client with Zhipu baseURL', async () => {
+      mockChatCompletionsCreate.mockResolvedValue(
+        createMockOpenAIResponse({ content: 'Response' })
+      );
+
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
+      await provider.chat({
+        messages: [{ role: 'user', content: 'Test' }],
+        model: 'glm-4.6',
+      });
+
+      expect(OpenAI).toHaveBeenCalledWith({
+        apiKey: 'test-zhipu-key',
+        baseURL: 'https://api.z.ai/api/paas/v4',
+      });
     });
   });
 
@@ -425,10 +442,10 @@ describe('OpenAIChatProvider', () => {
           })
         );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Search for test query' }],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
         tools: mockTools,
       });
 
@@ -477,10 +494,10 @@ describe('OpenAIChatProvider', () => {
           })
         );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Search and list docs' }],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
         tools: mockTools,
       });
 
@@ -539,10 +556,10 @@ describe('OpenAIChatProvider', () => {
           })
         );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Complex query' }],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
         tools: mockTools,
       });
 
@@ -560,10 +577,10 @@ describe('OpenAIChatProvider', () => {
         })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
       await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
         tools: mockTools,
       });
 
@@ -602,7 +619,8 @@ describe('OpenAIChatProvider', () => {
         toolExecutors,
       });
 
-      // Always return tool calls to trigger max turns
+      // Always return tool calls to trigger infinite loop
+      // Use mockImplementation to create a new stream each time
       mockChatCompletionsCreate.mockImplementation(() =>
         createMockOpenAIResponse({
           content: null,
@@ -620,10 +638,11 @@ describe('OpenAIChatProvider', () => {
         })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
+
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Trigger loop' }],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
         tools: [
           {
             name: 'search_rag',
@@ -636,10 +655,11 @@ describe('OpenAIChatProvider', () => {
         ],
       });
 
-      // Should complete gracefully with end_turn (not throw)
-      expect(result.stopReason).toBe('end_turn');
-      // Should have called 10 times (max turns)
+      // Should have called 10 times
       expect(mockChatCompletionsCreate).toHaveBeenCalledTimes(10);
+      // Should complete with end_turn (not throw)
+      expect(result.stopReason).toBe('end_turn');
+      expect(result.content).toBe('');
     });
   });
 
@@ -651,44 +671,32 @@ describe('OpenAIChatProvider', () => {
     it('should throw error when API key is not configured', async () => {
       mockGetProviderApiKey.mockResolvedValue(null);
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
 
       await expect(
         provider.chat({
           messages: [{ role: 'user', content: 'Test' }],
-          model: 'gpt-4o',
+          model: 'glm-4.6',
         })
-      ).rejects.toThrow('OpenAI API key not configured');
+      ).rejects.toThrow('Zhipu API key not configured');
     });
 
     it('should handle empty stream gracefully', async () => {
-      // Return an empty stream with just a finish chunk
-      mockChatCompletionsCreate.mockImplementation(() =>
+      // Return an empty async iterator (no chunks)
+      mockChatCompletionsCreate.mockResolvedValue(
         (async function* () {
-          yield {
-            id: 'chatcmpl-test',
-            object: 'chat.completion.chunk',
-            created: Date.now(),
-            model: 'gpt-4o',
-            choices: [
-              {
-                index: 0,
-                delta: {},
-                finish_reason: 'stop',
-              },
-            ],
-            usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
-          };
+          // Empty stream
         })()
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
+
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
       });
 
-      // Should complete with empty content
+      // Should complete with default values
       expect(result.content).toBe('');
       expect(result.stopReason).toBe('end_turn');
     });
@@ -727,10 +735,10 @@ describe('OpenAIChatProvider', () => {
           })
         );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Search' }],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
         tools: [
           {
             name: 'search_rag',
@@ -782,10 +790,10 @@ describe('OpenAIChatProvider', () => {
           })
         );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Use unknown tool' }],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
         tools: [
           {
             name: 'unknown_tool',
@@ -836,10 +844,10 @@ describe('OpenAIChatProvider', () => {
           })
         );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
         tools: [
           {
             name: 'search_rag',
@@ -873,10 +881,10 @@ describe('OpenAIChatProvider', () => {
         })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
       });
 
       expect(result.stopReason).toBe('end_turn');
@@ -890,10 +898,10 @@ describe('OpenAIChatProvider', () => {
         })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
       });
 
       expect(result.stopReason).toBe('max_tokens');
@@ -907,10 +915,10 @@ describe('OpenAIChatProvider', () => {
         })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
       });
 
       expect(result.stopReason).toBe('end_turn');
@@ -921,12 +929,12 @@ describe('OpenAIChatProvider', () => {
   // Factory Function Tests
   // ===========================================================================
 
-  describe('createOpenAIProvider factory', () => {
-    it('should create an OpenAIChatProvider instance', () => {
-      const provider = createOpenAIProvider(mockPool, mockContext);
+  describe('createZhipuProvider factory', () => {
+    it('should create a ZhipuChatProvider instance', () => {
+      const provider = createZhipuProvider(mockPool, mockContext);
 
-      expect(provider).toBeInstanceOf(OpenAIChatProvider);
-      expect(provider.name).toBe('openai');
+      expect(provider).toBeInstanceOf(ZhipuChatProvider);
+      expect(provider.name).toBe('zhipu');
     });
   });
 
@@ -940,14 +948,14 @@ describe('OpenAIChatProvider', () => {
         createMockOpenAIResponse({ content: 'Response' })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
       await provider.chat({
         messages: [
           { role: 'user', content: 'First message' },
           { role: 'assistant', content: 'First response' },
           { role: 'user', content: 'Second message' },
         ],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
       });
 
       expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
@@ -977,10 +985,10 @@ describe('OpenAIChatProvider', () => {
         })
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
       });
 
       expect(result.usage).toEqual({
@@ -991,18 +999,18 @@ describe('OpenAIChatProvider', () => {
     });
 
     it('should handle missing usage data', async () => {
-      // Stream without usage data in final chunk
-      mockChatCompletionsCreate.mockImplementation(() =>
+      // Return stream with no usage info in final chunk
+      mockChatCompletionsCreate.mockResolvedValue(
         (async function* () {
           yield {
             id: 'chatcmpl-test',
             object: 'chat.completion.chunk',
             created: Date.now(),
-            model: 'gpt-4o',
+            model: 'glm-4.6',
             choices: [
               {
                 index: 0,
-                delta: { content: 'Response' },
+                delta: { role: 'assistant', content: 'Response' },
                 finish_reason: null,
               },
             ],
@@ -1011,7 +1019,7 @@ describe('OpenAIChatProvider', () => {
             id: 'chatcmpl-test',
             object: 'chat.completion.chunk',
             created: Date.now(),
-            model: 'gpt-4o',
+            model: 'glm-4.6',
             choices: [
               {
                 index: 0,
@@ -1024,10 +1032,10 @@ describe('OpenAIChatProvider', () => {
         })()
       );
 
-      const provider = new OpenAIChatProvider(mockPool, mockContext);
+      const provider = new ZhipuChatProvider(mockPool, mockContext);
       const result = await provider.chat({
         messages: [{ role: 'user', content: 'Test' }],
-        model: 'gpt-4o',
+        model: 'glm-4.6',
       });
 
       expect(result.usage).toEqual({

--- a/apps/server/src/services/chat-providers/anthropic.ts
+++ b/apps/server/src/services/chat-providers/anthropic.ts
@@ -201,6 +201,8 @@ export class AnthropicChatProvider implements ChatProvider {
                   (message.usage?.input_tokens ?? 0) + (message.usage?.output_tokens ?? 0),
               },
               stopReason: 'end_turn',
+              // Include result text as fallback when no assistant message was streamed
+              fallbackText: typeof message.result === 'string' ? message.result : undefined,
             };
           } else if (message.subtype === 'error_max_turns') {
             yield {
@@ -227,6 +229,7 @@ export class AnthropicChatProvider implements ChatProvider {
     const toolCalls: ChatToolCall[] = [];
     let usage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
     let stopReason: ChatStopReason = 'end_turn';
+    let fallbackText: string | undefined;
 
     try {
       for await (const chunk of this.streamChat(params)) {
@@ -246,6 +249,7 @@ export class AnthropicChatProvider implements ChatProvider {
           case 'done':
             usage = chunk.usage ?? usage;
             stopReason = chunk.stopReason ?? stopReason;
+            fallbackText = chunk.fallbackText;
             break;
         }
       }
@@ -254,8 +258,11 @@ export class AnthropicChatProvider implements ChatProvider {
       throw error;
     }
 
+    // Use fallback text when no content was captured from assistant messages
+    const finalContent = content || fallbackText || '';
+
     return {
-      content,
+      content: finalContent,
       toolCalls,
       stopReason,
       usage,

--- a/apps/server/src/services/chat-providers/google.ts
+++ b/apps/server/src/services/chat-providers/google.ts
@@ -1,0 +1,489 @@
+/**
+ * Google Gemini Chat Provider
+ *
+ * Phase 16B: Google provider implementation with manual tool execution loop.
+ * Implements the ChatProvider interface for Google Gemini models.
+ */
+
+import {
+  type Content,
+  type FunctionCall,
+  type FunctionDeclarationsTool,
+  type FunctionResponse,
+  GoogleGenerativeAI,
+  type Part,
+  SchemaType,
+} from '@google/generative-ai';
+import type { Pool } from 'pg';
+import { buildAgentTools } from '../../agent/tools.js';
+import { mapGoogleStopReason } from './adapters.js';
+import { getProviderApiKey } from './index.js';
+import type {
+  ChatContentBlock,
+  ChatMessage,
+  ChatParams,
+  ChatProvider,
+  ChatResponse,
+  ChatStopReason,
+  ChatStreamChunk,
+  ChatToolCall,
+  ProviderCapabilities,
+  ToolContext,
+} from './types.js';
+
+/**
+ * Google Gemini Chat Provider Implementation
+ *
+ * Key features:
+ * - Manual tool execution loop (max 10 turns)
+ * - Converts normalized ChatTool[] to Google functionDeclaration format
+ * - Handles system prompts via systemInstruction parameter
+ * - Executes tools using buildAgentTools().toolExecutors
+ * - Supports streaming via generateContentStream()
+ */
+export class GoogleChatProvider implements ChatProvider {
+  readonly name = 'google' as const;
+  readonly capabilities: ProviderCapabilities = {
+    supportsTools: true,
+    supportsStreaming: true,
+    supportsVision: true,
+    maxContextTokens: 1000000, // Gemini supports up to 1M context window
+  };
+
+  constructor(
+    private readonly db: Pool,
+    private readonly context: ToolContext
+  ) {}
+
+  /**
+   * Send chat message with manual tool execution loop (non-streaming)
+   * Internally uses streamChat() and accumulates results
+   */
+  async chat(params: ChatParams): Promise<ChatResponse> {
+    let content = '';
+    const toolCalls: ChatToolCall[] = [];
+    let usage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+    let stopReason: ChatStopReason = 'end_turn';
+
+    for await (const chunk of this.streamChat(params)) {
+      switch (chunk.type) {
+        case 'text':
+          content += chunk.text ?? '';
+          break;
+        case 'tool_start':
+          if (chunk.toolCall?.id && chunk.toolCall?.name) {
+            toolCalls.push({
+              id: chunk.toolCall.id,
+              name: chunk.toolCall.name,
+              input: chunk.toolCall.input, // May be undefined, updated in tool_end
+            });
+          }
+          break;
+        case 'tool_end':
+          // Update tool call with parsed input (available after arguments accumulated)
+          if (chunk.toolCall?.id && chunk.toolCall?.input !== undefined) {
+            const tc = toolCalls.find((t) => t.id === chunk.toolCall?.id);
+            if (tc) {
+              tc.input = chunk.toolCall.input;
+            }
+          }
+          break;
+        case 'done':
+          usage = chunk.usage ?? usage;
+          stopReason = chunk.stopReason ?? stopReason;
+          break;
+      }
+    }
+
+    return {
+      content,
+      toolCalls,
+      stopReason,
+      usage,
+      model: params.model,
+      provider: 'google',
+    };
+  }
+
+  /**
+   * Send chat message with streaming support
+   * Implements manual tool execution loop with Google Gemini streaming API
+   */
+  async *streamChat(params: ChatParams): AsyncGenerator<ChatStreamChunk, void, unknown> {
+    // Get API key
+    const apiKey = await getProviderApiKey(this.db, 'google');
+    if (!apiKey) {
+      throw new Error(
+        'Google API key not configured. Please set GOOGLE_API_KEY environment variable or configure in Settings > API Keys.'
+      );
+    }
+
+    // Create Google AI client
+    const genAI = new GoogleGenerativeAI(apiKey);
+
+    // Build tools and executors
+    const { toolExecutors } = buildAgentTools(this.db, this.context);
+
+    // Convert tools to Google functionDeclaration format
+    // Using type assertion as Google SDK expects specific Schema types
+    // but our normalized format uses JSON Schema which is compatible at runtime
+    const tools: FunctionDeclarationsTool | undefined = params.tools
+      ? ({
+          functionDeclarations: params.tools.map((tool) => ({
+            name: tool.name,
+            description: tool.description,
+            parameters: {
+              type: SchemaType.OBJECT,
+              properties: this.convertPropertiesToGoogleSchema(tool.inputSchema.properties),
+              required: tool.inputSchema.required,
+            },
+          })),
+        } as FunctionDeclarationsTool)
+      : undefined;
+
+    // Prepare model with system instruction if provided
+    const model = genAI.getGenerativeModel({
+      model: params.model,
+      systemInstruction: params.systemPrompt,
+    });
+
+    // Convert messages to Google Content format
+    const contents = this.prepareMessages(params);
+
+    // Manual tool execution loop (max 10 turns)
+    const MAX_TURNS = 10;
+    let turnCount = 0;
+    const conversationHistory = [...contents];
+
+    while (turnCount < MAX_TURNS) {
+      turnCount++;
+
+      // Create streaming request
+      const request: Parameters<typeof model.generateContentStream>[0] = {
+        contents: conversationHistory,
+        tools: tools ? [tools] : undefined,
+        generationConfig: {
+          maxOutputTokens: params.maxTokens,
+          temperature: params.temperature,
+          stopSequences: params.stopSequences,
+        },
+      };
+
+      const stream = await model.generateContentStream(request);
+
+      // Accumulate response parts
+      const responseParts: Part[] = [];
+      const toolCallIds: string[] = [];
+      let finishReason: string | undefined = undefined;
+      let inputTokens = 0;
+      let outputTokens = 0;
+
+      // Stream chunks
+      for await (const chunk of stream.stream) {
+        if (!chunk.candidates?.[0]) continue;
+
+        const candidate = chunk.candidates[0];
+        finishReason = candidate.finishReason;
+
+        // Stream text content
+        if (candidate.content?.parts) {
+          for (const part of candidate.content.parts) {
+            responseParts.push(part);
+
+            // Emit text if present
+            if ('text' in part && part.text) {
+              yield { type: 'text', text: part.text };
+            }
+
+            // Emit tool_start when we see a function call
+            if ('functionCall' in part && part.functionCall) {
+              const fc = part.functionCall as FunctionCall;
+              const toolCallId = `google-${toolCallIds.length}-${Date.now()}`;
+              toolCallIds.push(toolCallId);
+              yield {
+                type: 'tool_start',
+                toolCall: { id: toolCallId, name: fc.name, input: fc.args },
+              };
+            }
+          }
+        }
+
+        // Capture token usage from metadata
+        if (chunk.usageMetadata) {
+          inputTokens = chunk.usageMetadata.promptTokenCount ?? 0;
+          outputTokens = chunk.usageMetadata.candidatesTokenCount ?? 0;
+        }
+      }
+
+      // Check for function calls in response
+      const functionCalls = responseParts.filter((part) => 'functionCall' in part) as Array<{
+        functionCall: FunctionCall;
+      }>;
+
+      // If no tool calls, we're done
+      if (functionCalls.length === 0) {
+        yield {
+          type: 'done',
+          usage: {
+            inputTokens,
+            outputTokens,
+            totalTokens: inputTokens + outputTokens,
+          },
+          stopReason: mapGoogleStopReason(finishReason),
+        };
+        return;
+      }
+
+      // Add assistant's response to conversation history
+      conversationHistory.push({
+        role: 'model',
+        parts: responseParts,
+      });
+
+      // Execute tool calls
+      const functionResponses: FunctionResponse[] = [];
+
+      for (let i = 0; i < functionCalls.length; i++) {
+        const fc = functionCalls[i].functionCall;
+        const toolCallId = toolCallIds[i] ?? `google-${i}-${Date.now()}`;
+
+        try {
+          const normalizedName = fc.name;
+          const executor = toolExecutors[normalizedName];
+
+          if (!executor) {
+            throw new Error(`Unknown tool: ${normalizedName}`);
+          }
+
+          // Execute tool with args
+          const result = await executor(fc.args as Record<string, unknown>);
+
+          // Yield tool_end with input
+          yield { type: 'tool_end', toolCall: { id: toolCallId, name: fc.name, input: fc.args } };
+
+          // Add function response
+          functionResponses.push({
+            name: fc.name,
+            response: { result },
+          });
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : 'Tool execution failed';
+          yield { type: 'tool_end', toolCall: { id: toolCallId, name: fc.name, input: fc.args } };
+
+          functionResponses.push({
+            name: fc.name,
+            response: { error: errorMessage },
+          });
+        }
+      }
+
+      // Add function responses to conversation history
+      conversationHistory.push({
+        role: 'user',
+        parts: functionResponses.map((fr) => ({
+          functionResponse: fr,
+        })),
+      });
+
+      // Continue to next turn
+    }
+
+    // Max turns reached
+    yield {
+      type: 'done',
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      stopReason: 'end_turn',
+    };
+  }
+
+  /**
+   * Check if provider is configured (has API key)
+   */
+  async isConfigured(): Promise<boolean> {
+    const apiKey = await getProviderApiKey(this.db, 'google');
+    return apiKey !== null;
+  }
+
+  /**
+   * Prepare messages for Google Gemini API
+   * Converts normalized ChatMessage[] to Google Content[] format
+   *
+   * Google format:
+   * - role: 'user' | 'model' (not 'assistant')
+   * - parts: array of text, inlineData, functionCall, or functionResponse
+   *
+   * Note: System prompts handled via systemInstruction parameter, not in messages
+   */
+  private prepareMessages(params: ChatParams): Content[] {
+    const contents: Content[] = [];
+
+    for (const msg of params.messages) {
+      // Skip system messages (handled via systemInstruction)
+      if (msg.role === 'system') {
+        continue;
+      }
+
+      // Map role: assistant -> model
+      const role = msg.role === 'assistant' ? 'model' : 'user';
+
+      // Convert content to parts
+      const parts = this.messageToParts(msg);
+
+      contents.push({ role, parts });
+    }
+
+    return contents;
+  }
+
+  /**
+   * Convert a ChatMessage to Google Parts array
+   */
+  private messageToParts(msg: ChatMessage): Part[] {
+    // Simple text message
+    if (typeof msg.content === 'string') {
+      return [{ text: msg.content }];
+    }
+
+    // Complex content blocks
+    const blocks = msg.content as ChatContentBlock[];
+    const parts: Part[] = [];
+
+    for (const block of blocks) {
+      switch (block.type) {
+        case 'text':
+          if (block.text) {
+            parts.push({ text: block.text });
+          }
+          break;
+
+        case 'tool_use':
+          // Google uses functionCall format
+          if (block.name && block.input) {
+            parts.push({
+              functionCall: {
+                name: block.name,
+                args: block.input as Record<string, unknown>,
+              },
+            });
+          }
+          break;
+
+        case 'tool_result':
+          // Google uses functionResponse format
+          if (block.toolUseId && block.content !== undefined) {
+            // Extract function name from toolUseId or content
+            const functionName = this.extractFunctionNameFromToolResult(block);
+            parts.push({
+              functionResponse: {
+                name: functionName,
+                response: block.isError ? { error: block.content } : { result: block.content },
+              },
+            });
+          }
+          break;
+
+        case 'image':
+          // Google supports inline images via inlineData
+          if (block.source?.type === 'base64' && block.source.data) {
+            parts.push({
+              inlineData: {
+                mimeType: block.source.mediaType ?? 'image/png',
+                data: block.source.data,
+              },
+            });
+          }
+          break;
+      }
+    }
+
+    return parts.length > 0 ? parts : [{ text: '' }];
+  }
+
+  /**
+   * Convert JSON Schema properties to Google Schema format
+   */
+  private convertPropertiesToGoogleSchema(
+    properties: Record<string, unknown>
+  ): Record<string, unknown> {
+    return Object.fromEntries(
+      Object.entries(properties).map(([key, value]) => [
+        key,
+        this.convertPropertyToGoogleSchema(value as Record<string, unknown>),
+      ])
+    );
+  }
+
+  /**
+   * Convert a JSON Schema property to Google Schema format
+   * Maps JSON Schema types to Google SchemaType enum values
+   */
+  private convertPropertyToGoogleSchema(prop: Record<string, unknown>): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+
+    if (prop.type) {
+      // Map JSON Schema type to Google SchemaType
+      const typeMap: Record<string, (typeof SchemaType)[keyof typeof SchemaType]> = {
+        string: SchemaType.STRING,
+        number: SchemaType.NUMBER,
+        integer: SchemaType.INTEGER,
+        boolean: SchemaType.BOOLEAN,
+        array: SchemaType.ARRAY,
+        object: SchemaType.OBJECT,
+      };
+      result.type = typeMap[prop.type as string] ?? SchemaType.STRING;
+    }
+
+    if (prop.description) {
+      result.description = prop.description;
+    }
+
+    if (prop.enum) {
+      result.enum = prop.enum;
+    }
+
+    if (prop.items && typeof prop.items === 'object') {
+      result.items = this.convertPropertyToGoogleSchema(prop.items as Record<string, unknown>);
+    }
+
+    if (prop.properties && typeof prop.properties === 'object') {
+      result.properties = this.convertPropertiesToGoogleSchema(
+        prop.properties as Record<string, unknown>
+      );
+    }
+
+    if (prop.required) {
+      result.required = prop.required;
+    }
+
+    return result;
+  }
+
+  /**
+   * Extract function name from tool result block
+   * Google requires function name in functionResponse, but our normalized
+   * format only has toolUseId. We extract from content or use a placeholder.
+   */
+  private extractFunctionNameFromToolResult(block: ChatContentBlock): string {
+    // Try to parse function name from content if it's a JSON string
+    if (typeof block.content === 'string') {
+      try {
+        const parsed = JSON.parse(block.content);
+        if (parsed.function_name || parsed.name) {
+          return parsed.function_name || parsed.name;
+        }
+      } catch {
+        // Not JSON, continue
+      }
+    }
+
+    // Fallback: use toolUseId or generic name
+    return block.toolUseId ?? 'unknown_function';
+  }
+}
+
+/**
+ * Factory function to create Google provider instance
+ */
+export function createGoogleProvider(db: Pool, context: ToolContext): ChatProvider {
+  return new GoogleChatProvider(db, context);
+}

--- a/apps/server/src/services/chat-providers/index.ts
+++ b/apps/server/src/services/chat-providers/index.ts
@@ -11,9 +11,12 @@ import type { Pool } from 'pg';
 import { getApiKeyService } from '../api-key-service.js';
 import { getModelConfigService } from '../model-config-service.js';
 import { createAnthropicProvider } from './anthropic.js';
+import { createGoogleProvider } from './google.js';
+import { createMoonshotProvider } from './moonshot.js';
 import { createOllamaProvider } from './ollama.js';
 import { createOpenAIProvider } from './openai.js';
 import type { ChatProvider, ChatProviderFactory, ChatProviderType, ToolContext } from './types.js';
+import { createZhipuProvider } from './zhipu.js';
 
 // =============================================================================
 // Provider Registry
@@ -240,5 +243,8 @@ export * from './adapters.js';
 
 // Register all available chat providers
 registerChatProvider('anthropic', createAnthropicProvider);
+registerChatProvider('google', createGoogleProvider);
+registerChatProvider('moonshot', createMoonshotProvider);
 registerChatProvider('openai', createOpenAIProvider);
 registerChatProvider('ollama', createOllamaProvider);
+registerChatProvider('zhipu', createZhipuProvider);

--- a/apps/server/src/services/chat-providers/moonshot.ts
+++ b/apps/server/src/services/chat-providers/moonshot.ts
@@ -1,0 +1,351 @@
+/**
+ * Moonshot (Kimi) Chat Provider
+ *
+ * Phase 16D: Moonshot provider implementation with manual tool execution loop.
+ * Implements the ChatProvider interface for Kimi models.
+ *
+ * Uses OpenAI-compatible API at api.moonshot.cn
+ * Models: kimi-k2-0905-preview, kimi-k2-thinking, kimi-k2-thinking-turbo
+ *
+ * Special Features:
+ * - Thinking mode for kimi-k2-thinking* models (adds reasoning tokens)
+ * - Built-in web search available via $web_search tool
+ * - 256K context window for Kimi K2 models
+ */
+
+import OpenAI from 'openai';
+import type {
+  ChatCompletionMessageParam,
+  ChatCompletionTool,
+} from 'openai/resources/chat/completions.js';
+import type { Pool } from 'pg';
+import { buildAgentTools } from '../../agent/tools.js';
+import { mapOpenAIStopReason, toOpenAIMessages, toOpenAITool } from './adapters.js';
+import { getProviderApiKey } from './index.js';
+import type {
+  ChatParams,
+  ChatProvider,
+  ChatResponse,
+  ChatStopReason,
+  ChatStreamChunk,
+  ChatToolCall,
+  ProviderCapabilities,
+  ToolContext,
+} from './types.js';
+
+/**
+ * Moonshot Chat Provider Implementation
+ *
+ * Key features:
+ * - Manual tool execution loop (max 10 turns)
+ * - OpenAI-compatible API at api.moonshot.cn
+ * - Thinking mode for reasoning models (adds extra_body parameter)
+ * - Uses standard OpenAI function calling format
+ */
+export class MoonshotChatProvider implements ChatProvider {
+  readonly name = 'moonshot' as const;
+  readonly capabilities: ProviderCapabilities = {
+    supportsTools: true,
+    supportsStreaming: true,
+    supportsVision: false, // Moonshot does not support vision yet
+    maxContextTokens: 256000, // Kimi K2 supports 256K context
+  };
+
+  constructor(
+    private readonly db: Pool,
+    private readonly context: ToolContext
+  ) {}
+
+  /**
+   * Send chat message with manual tool execution loop (non-streaming)
+   * Internally uses streamChat() and accumulates results
+   */
+  async chat(params: ChatParams): Promise<ChatResponse> {
+    let content = '';
+    const toolCalls: ChatToolCall[] = [];
+    let usage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+    let stopReason: ChatStopReason = 'end_turn';
+
+    for await (const chunk of this.streamChat(params)) {
+      switch (chunk.type) {
+        case 'text':
+          content += chunk.text ?? '';
+          break;
+        case 'tool_start':
+          if (chunk.toolCall?.id && chunk.toolCall?.name) {
+            toolCalls.push({
+              id: chunk.toolCall.id,
+              name: chunk.toolCall.name,
+              input: chunk.toolCall.input, // May be undefined, updated in tool_end
+            });
+          }
+          break;
+        case 'tool_end':
+          // Update tool call with parsed input (available after arguments accumulated)
+          if (chunk.toolCall?.id && chunk.toolCall?.input !== undefined) {
+            const tc = toolCalls.find((t) => t.id === chunk.toolCall?.id);
+            if (tc) {
+              tc.input = chunk.toolCall.input;
+            }
+          }
+          break;
+        case 'done':
+          usage = chunk.usage ?? usage;
+          stopReason = chunk.stopReason ?? stopReason;
+          break;
+      }
+    }
+
+    return {
+      content,
+      toolCalls,
+      stopReason,
+      usage,
+      model: params.model,
+      provider: 'moonshot',
+    };
+  }
+
+  /**
+   * Send chat message with streaming support
+   * Implements manual tool execution loop with Moonshot streaming API
+   */
+  async *streamChat(params: ChatParams): AsyncGenerator<ChatStreamChunk, void, unknown> {
+    // Get API key
+    const apiKey = await getProviderApiKey(this.db, 'moonshot');
+    if (!apiKey) {
+      throw new Error(
+        'Moonshot API key not configured. Please set MOONSHOT_API_KEY environment variable or configure in Settings > API Keys.'
+      );
+    }
+
+    // Create Moonshot client (OpenAI-compatible)
+    const client = new OpenAI({
+      apiKey,
+      baseURL: 'https://api.moonshot.cn/v1',
+    });
+
+    // Build tools and executors
+    const { toolExecutors } = buildAgentTools(this.db, this.context);
+
+    // Convert tools to OpenAI format
+    const openaiTools: ChatCompletionTool[] | undefined = params.tools
+      ? params.tools.map(toOpenAITool)
+      : undefined;
+
+    // Convert messages to OpenAI format (handles system prompt)
+    const messages = this.prepareMessages(params);
+
+    // Prepare extra_body for thinking mode
+    const extraBody = this.prepareExtraBody(params.model);
+
+    // Manual tool execution loop (max 10 turns)
+    const MAX_TURNS = 10;
+    let turnCount = 0;
+
+    while (turnCount < MAX_TURNS) {
+      turnCount++;
+
+      // Create streaming request
+      const stream = await client.chat.completions.create({
+        model: params.model,
+        messages,
+        tools: openaiTools,
+        max_tokens: params.maxTokens,
+        temperature: params.temperature,
+        stop: params.stopSequences,
+        stream: true,
+        ...(extraBody && { extra_body: extraBody }),
+      });
+
+      // Track accumulated tool calls by index
+      const toolCallsAccum = new Map<number, { id: string; name: string; arguments: string }>();
+      // Track which tool indices have emitted tool_start to avoid duplicates
+      const emittedToolStarts = new Set<number>();
+      let finishReason: string | null = null;
+      let promptTokens = 0;
+      let completionTokens = 0;
+
+      for await (const chunk of stream) {
+        const choice = chunk.choices[0];
+        if (!choice) continue;
+
+        finishReason = choice.finish_reason ?? finishReason;
+        const delta = choice.delta;
+
+        // Stream text content
+        if (delta?.content) {
+          yield { type: 'text', text: delta.content };
+        }
+
+        // Accumulate tool calls (streamed incrementally by index)
+        if (delta?.tool_calls) {
+          for (const tc of delta.tool_calls) {
+            const existing = toolCallsAccum.get(tc.index) ?? {
+              id: '',
+              name: '',
+              arguments: '',
+            };
+            if (tc.id) existing.id = tc.id;
+            if (tc.function?.name) {
+              existing.name = tc.function.name;
+              // Yield tool_start only once per tool (when we first see the name)
+              if (!emittedToolStarts.has(tc.index)) {
+                emittedToolStarts.add(tc.index);
+                yield {
+                  type: 'tool_start',
+                  toolCall: { id: existing.id, name: existing.name },
+                };
+              }
+            }
+            if (tc.function?.arguments) {
+              existing.arguments += tc.function.arguments;
+            }
+            toolCallsAccum.set(tc.index, existing);
+          }
+        }
+
+        // Capture usage from final chunk
+        if (chunk.usage) {
+          promptTokens = chunk.usage.prompt_tokens ?? 0;
+          completionTokens = chunk.usage.completion_tokens ?? 0;
+        }
+      }
+
+      // If no tool calls, we're done
+      if (finishReason !== 'tool_calls' || toolCallsAccum.size === 0) {
+        yield {
+          type: 'done',
+          usage: {
+            inputTokens: promptTokens,
+            outputTokens: completionTokens,
+            totalTokens: promptTokens + completionTokens,
+          },
+          stopReason: mapOpenAIStopReason(finishReason),
+        };
+        return;
+      }
+
+      // Execute tool calls
+      const toolCallsArray = Array.from(toolCallsAccum.values());
+
+      // Add assistant message with tool calls to history
+      messages.push({
+        role: 'assistant',
+        content: null,
+        tool_calls: toolCallsArray.map((tc) => ({
+          id: tc.id,
+          type: 'function' as const,
+          function: { name: tc.name, arguments: tc.arguments },
+        })),
+      });
+
+      // Execute each tool
+      for (const tc of toolCallsArray) {
+        try {
+          const input = JSON.parse(tc.arguments);
+          const normalizedName = tc.name;
+          const executor = toolExecutors[normalizedName];
+
+          if (!executor) {
+            throw new Error(`Unknown tool: ${normalizedName}`);
+          }
+
+          const result = await executor(input);
+
+          // Yield tool_end with parsed input
+          yield { type: 'tool_end', toolCall: { id: tc.id, name: tc.name, input } };
+
+          // Add tool result to messages
+          messages.push({
+            role: 'tool',
+            content: result,
+            tool_call_id: tc.id,
+          });
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : 'Tool execution failed';
+          // Include input even on error (may have been parsed successfully)
+          const parsedInput = (() => {
+            try {
+              return JSON.parse(tc.arguments);
+            } catch {
+              return undefined;
+            }
+          })();
+          yield { type: 'tool_end', toolCall: { id: tc.id, name: tc.name, input: parsedInput } };
+          messages.push({
+            role: 'tool',
+            content: JSON.stringify({ error: errorMessage }),
+            tool_call_id: tc.id,
+          });
+        }
+      }
+      // Continue to next turn
+    }
+
+    // Max turns reached (not token limit, so use end_turn)
+    yield {
+      type: 'done',
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      stopReason: 'end_turn',
+    };
+  }
+
+  /**
+   * Check if provider is configured (has API key)
+   */
+  async isConfigured(): Promise<boolean> {
+    const apiKey = await getProviderApiKey(this.db, 'moonshot');
+    return apiKey !== null;
+  }
+
+  /**
+   * Prepare messages for Moonshot API
+   * Handles system prompt by converting to system message
+   */
+  private prepareMessages(params: ChatParams): ChatCompletionMessageParam[] {
+    const messages: ChatCompletionMessageParam[] = [];
+
+    // Add system message if provided
+    if (params.systemPrompt) {
+      messages.push({
+        role: 'system',
+        content: params.systemPrompt,
+      });
+    }
+
+    // Convert normalized messages to OpenAI format
+    const openaiMessages = toOpenAIMessages(params.messages);
+    messages.push(...openaiMessages);
+
+    return messages;
+  }
+
+  /**
+   * Prepare extra_body parameter for thinking mode
+   * Kimi K2 thinking models support extended reasoning via extra_body
+   *
+   * @param model Model name
+   * @returns extra_body object or undefined
+   */
+  private prepareExtraBody(model: string): Record<string, unknown> | undefined {
+    // Check if model name includes 'thinking' (e.g., kimi-k2-thinking, kimi-k2-thinking-turbo)
+    if (model.toLowerCase().includes('thinking')) {
+      return {
+        thinking: {
+          type: 'enabled',
+          max_tokens: 4096, // Allocate 4K tokens for reasoning
+        },
+      };
+    }
+
+    return undefined;
+  }
+}
+
+/**
+ * Factory function to create Moonshot provider instance
+ */
+export function createMoonshotProvider(db: Pool, context: ToolContext): ChatProvider {
+  return new MoonshotChatProvider(db, context);
+}

--- a/apps/server/src/services/chat-providers/openai-compatible.ts
+++ b/apps/server/src/services/chat-providers/openai-compatible.ts
@@ -1,0 +1,343 @@
+/**
+ * OpenAI-Compatible Base Chat Provider
+ *
+ * Phase 16D: Reusable base class for OpenAI-compatible API providers.
+ * Used by Zhipu (Z.AI) and Moonshot (Kimi) providers which use OpenAI-compatible endpoints.
+ *
+ * Features:
+ * - Configurable baseURL and API key provider name
+ * - Manual tool execution loop (max 10 turns)
+ * - Streaming support via OpenAI SDK
+ * - Reuses existing OpenAI adapters (toOpenAITool, toOpenAIMessages, etc.)
+ */
+
+import OpenAI from 'openai';
+import type {
+  ChatCompletionMessageParam,
+  ChatCompletionTool,
+} from 'openai/resources/chat/completions.js';
+import type { Pool } from 'pg';
+import { buildAgentTools } from '../../agent/tools.js';
+import { mapOpenAIStopReason, toOpenAIMessages, toOpenAITool } from './adapters.js';
+import { getProviderApiKey } from './index.js';
+import type {
+  ChatParams,
+  ChatProvider,
+  ChatProviderType,
+  ChatResponse,
+  ChatStopReason,
+  ChatStreamChunk,
+  ChatToolCall,
+  ProviderCapabilities,
+  ToolContext,
+} from './types.js';
+
+/**
+ * Configuration for OpenAI-compatible providers
+ */
+export interface OpenAICompatibleConfig {
+  /** Provider name (e.g., 'zhipu', 'moonshot') */
+  providerName: ChatProviderType;
+  /** Base URL for the API endpoint */
+  baseURL: string;
+  /** API key provider name (used to look up the key in ApiKeyService or env) */
+  apiKeyProvider: string;
+  /** Maximum context window in tokens */
+  maxContextTokens: number;
+  /** Whether the provider supports vision/image input */
+  supportsVision: boolean;
+}
+
+/**
+ * OpenAI-Compatible Base Provider Implementation
+ *
+ * This base class provides a reusable implementation for any provider
+ * that implements the OpenAI chat completions API format.
+ *
+ * Key features:
+ * - Manual tool execution loop (max 10 turns)
+ * - Converts normalized ChatTool[] to OpenAI function calling format
+ * - Handles system prompts via system role messages
+ * - Executes tools using buildAgentTools().toolExecutors
+ * - Configurable endpoint and API key source
+ */
+export class OpenAICompatibleProvider implements ChatProvider {
+  readonly name: ChatProviderType;
+  readonly capabilities: ProviderCapabilities;
+
+  constructor(
+    protected readonly db: Pool,
+    protected readonly context: ToolContext,
+    protected readonly config: OpenAICompatibleConfig
+  ) {
+    this.name = config.providerName;
+    this.capabilities = {
+      supportsTools: true,
+      supportsStreaming: true,
+      supportsVision: config.supportsVision,
+      maxContextTokens: config.maxContextTokens,
+    };
+  }
+
+  /**
+   * Send chat message with manual tool execution loop (non-streaming)
+   * Internally uses streamChat() and accumulates results
+   */
+  async chat(params: ChatParams): Promise<ChatResponse> {
+    let content = '';
+    const toolCalls: ChatToolCall[] = [];
+    let usage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+    let stopReason: ChatStopReason = 'end_turn';
+
+    for await (const chunk of this.streamChat(params)) {
+      switch (chunk.type) {
+        case 'text':
+          content += chunk.text ?? '';
+          break;
+        case 'tool_start':
+          if (chunk.toolCall?.id && chunk.toolCall?.name) {
+            toolCalls.push({
+              id: chunk.toolCall.id,
+              name: chunk.toolCall.name,
+              input: chunk.toolCall.input, // May be undefined, updated in tool_end
+            });
+          }
+          break;
+        case 'tool_end':
+          // Update tool call with parsed input (available after arguments accumulated)
+          if (chunk.toolCall?.id && chunk.toolCall?.input !== undefined) {
+            const tc = toolCalls.find((t) => t.id === chunk.toolCall?.id);
+            if (tc) {
+              tc.input = chunk.toolCall.input;
+            }
+          }
+          break;
+        case 'done':
+          usage = chunk.usage ?? usage;
+          stopReason = chunk.stopReason ?? stopReason;
+          break;
+      }
+    }
+
+    return {
+      content,
+      toolCalls,
+      stopReason,
+      usage,
+      model: params.model,
+      provider: this.name,
+    };
+  }
+
+  /**
+   * Send chat message with streaming support
+   * Implements manual tool execution loop with OpenAI-compatible streaming API
+   */
+  async *streamChat(params: ChatParams): AsyncGenerator<ChatStreamChunk, void, unknown> {
+    // Get API key
+    const apiKey = await getProviderApiKey(this.db, this.config.apiKeyProvider);
+    if (!apiKey) {
+      throw new Error(
+        `${this.config.providerName} API key not configured. ` +
+          'Please set the API key in Settings > API Keys or via environment variable.'
+      );
+    }
+
+    // Create OpenAI client with custom baseURL
+    const client = new OpenAI({
+      apiKey,
+      baseURL: this.config.baseURL,
+    });
+
+    // Build tools and executors
+    const { toolExecutors } = buildAgentTools(this.db, this.context);
+
+    // Convert tools to OpenAI format
+    const openaiTools: ChatCompletionTool[] | undefined = params.tools
+      ? params.tools.map(toOpenAITool)
+      : undefined;
+
+    // Convert messages to OpenAI format (handles system prompt)
+    const messages = this.prepareMessages(params);
+
+    // Manual tool execution loop (max 10 turns)
+    const MAX_TURNS = 10;
+    let turnCount = 0;
+
+    while (turnCount < MAX_TURNS) {
+      turnCount++;
+
+      // Create streaming request
+      const stream = await client.chat.completions.create({
+        model: params.model,
+        messages,
+        tools: openaiTools,
+        max_tokens: params.maxTokens,
+        temperature: params.temperature,
+        stop: params.stopSequences,
+        stream: true,
+      });
+
+      // Track accumulated tool calls by index
+      const toolCallsAccum = new Map<number, { id: string; name: string; arguments: string }>();
+      // Track which tool indices have emitted tool_start to avoid duplicates
+      const emittedToolStarts = new Set<number>();
+      let finishReason: string | null = null;
+      let promptTokens = 0;
+      let completionTokens = 0;
+
+      for await (const chunk of stream) {
+        const choice = chunk.choices[0];
+        if (!choice) continue;
+
+        finishReason = choice.finish_reason ?? finishReason;
+        const delta = choice.delta;
+
+        // Stream text content
+        if (delta?.content) {
+          yield { type: 'text', text: delta.content };
+        }
+
+        // Accumulate tool calls (streamed incrementally by index)
+        if (delta?.tool_calls) {
+          for (const tc of delta.tool_calls) {
+            const existing = toolCallsAccum.get(tc.index) ?? {
+              id: '',
+              name: '',
+              arguments: '',
+            };
+            if (tc.id) existing.id = tc.id;
+            if (tc.function?.name) {
+              existing.name = tc.function.name;
+              // Yield tool_start only once per tool (when we first see the name)
+              if (!emittedToolStarts.has(tc.index)) {
+                emittedToolStarts.add(tc.index);
+                yield {
+                  type: 'tool_start',
+                  toolCall: { id: existing.id, name: existing.name },
+                };
+              }
+            }
+            if (tc.function?.arguments) {
+              existing.arguments += tc.function.arguments;
+            }
+            toolCallsAccum.set(tc.index, existing);
+          }
+        }
+
+        // Capture usage from final chunk
+        if (chunk.usage) {
+          promptTokens = chunk.usage.prompt_tokens ?? 0;
+          completionTokens = chunk.usage.completion_tokens ?? 0;
+        }
+      }
+
+      // If no tool calls, we're done
+      if (finishReason !== 'tool_calls' || toolCallsAccum.size === 0) {
+        yield {
+          type: 'done',
+          usage: {
+            inputTokens: promptTokens,
+            outputTokens: completionTokens,
+            totalTokens: promptTokens + completionTokens,
+          },
+          stopReason: mapOpenAIStopReason(finishReason),
+        };
+        return;
+      }
+
+      // Execute tool calls
+      const toolCallsArray = Array.from(toolCallsAccum.values());
+
+      // Add assistant message with tool calls to history
+      messages.push({
+        role: 'assistant',
+        content: null,
+        tool_calls: toolCallsArray.map((tc) => ({
+          id: tc.id,
+          type: 'function' as const,
+          function: { name: tc.name, arguments: tc.arguments },
+        })),
+      });
+
+      // Execute each tool
+      for (const tc of toolCallsArray) {
+        try {
+          const input = JSON.parse(tc.arguments);
+          const normalizedName = tc.name;
+          const executor = toolExecutors[normalizedName];
+
+          if (!executor) {
+            throw new Error(`Unknown tool: ${normalizedName}`);
+          }
+
+          const result = await executor(input);
+
+          // Yield tool_end with parsed input
+          yield { type: 'tool_end', toolCall: { id: tc.id, name: tc.name, input } };
+
+          // Add tool result to messages
+          messages.push({
+            role: 'tool',
+            content: result,
+            tool_call_id: tc.id,
+          });
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : 'Tool execution failed';
+          // Include input even on error (may have been parsed successfully)
+          const parsedInput = (() => {
+            try {
+              return JSON.parse(tc.arguments);
+            } catch {
+              return undefined;
+            }
+          })();
+          yield { type: 'tool_end', toolCall: { id: tc.id, name: tc.name, input: parsedInput } };
+          messages.push({
+            role: 'tool',
+            content: JSON.stringify({ error: errorMessage }),
+            tool_call_id: tc.id,
+          });
+        }
+      }
+      // Continue to next turn
+    }
+
+    // Max turns reached (not token limit, so use end_turn)
+    yield {
+      type: 'done',
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      stopReason: 'end_turn',
+    };
+  }
+
+  /**
+   * Check if provider is configured (has API key)
+   */
+  async isConfigured(): Promise<boolean> {
+    const apiKey = await getProviderApiKey(this.db, this.config.apiKeyProvider);
+    return apiKey !== null;
+  }
+
+  /**
+   * Prepare messages for OpenAI-compatible API
+   * Handles system prompt by converting to system message
+   */
+  private prepareMessages(params: ChatParams): ChatCompletionMessageParam[] {
+    const messages: ChatCompletionMessageParam[] = [];
+
+    // Add system message if provided
+    if (params.systemPrompt) {
+      messages.push({
+        role: 'system',
+        content: params.systemPrompt,
+      });
+    }
+
+    // Convert normalized messages to OpenAI format
+    const openaiMessages = toOpenAIMessages(params.messages);
+    messages.push(...openaiMessages);
+
+    return messages;
+  }
+}

--- a/apps/server/src/services/chat-providers/types.ts
+++ b/apps/server/src/services/chat-providers/types.ts
@@ -162,6 +162,8 @@ export interface ChatStreamChunk {
   usage?: TokenUsage;
   /** For done chunks - the stop reason */
   stopReason?: ChatStopReason;
+  /** For done chunks - fallback text when no content was streamed (Anthropic SDK) */
+  fallbackText?: string;
 }
 
 /**

--- a/apps/server/src/services/chat-providers/zhipu.ts
+++ b/apps/server/src/services/chat-providers/zhipu.ts
@@ -1,0 +1,322 @@
+/**
+ * Z.AI (Zhipu) Chat Provider
+ *
+ * Phase 16B: Zhipu provider implementation using OpenAI-compatible API.
+ * API Endpoint: https://api.z.ai/api/paas/v4
+ * Models: GLM-4.6, GLM-4.5-Air
+ */
+
+import OpenAI from 'openai';
+import type {
+  ChatCompletionMessageParam,
+  ChatCompletionTool,
+} from 'openai/resources/chat/completions.js';
+import type { Pool } from 'pg';
+import { buildAgentTools } from '../../agent/tools.js';
+import { mapOpenAIStopReason, toOpenAIMessages, toOpenAITool } from './adapters.js';
+import { getProviderApiKey } from './index.js';
+import type {
+  ChatParams,
+  ChatProvider,
+  ChatResponse,
+  ChatStopReason,
+  ChatStreamChunk,
+  ChatToolCall,
+  ProviderCapabilities,
+  ToolContext,
+} from './types.js';
+
+/**
+ * Z.AI (Zhipu) Chat Provider Implementation
+ *
+ * Uses OpenAI-compatible API at api.z.ai/api/paas/v4
+ * Supports GLM-4 series models with tool calling and streaming
+ *
+ * Key features:
+ * - OpenAI-compatible API format
+ * - Manual tool execution loop (max 10 turns)
+ * - Built-in web_search tool support (future enhancement)
+ * - Handles system prompts via system role messages
+ */
+export class ZhipuChatProvider implements ChatProvider {
+  readonly name = 'zhipu' as const;
+  readonly capabilities: ProviderCapabilities = {
+    supportsTools: true,
+    supportsStreaming: true,
+    supportsVision: false, // GLM-4V supports vision, but not implemented yet
+    maxContextTokens: 128000, // GLM-4.6 context window
+  };
+
+  constructor(
+    private readonly db: Pool,
+    private readonly context: ToolContext
+  ) {}
+
+  /**
+   * Send chat message with manual tool execution loop (non-streaming)
+   * Internally uses streamChat() and accumulates results
+   */
+  async chat(params: ChatParams): Promise<ChatResponse> {
+    let content = '';
+    const toolCalls: ChatToolCall[] = [];
+    let usage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+    let stopReason: ChatStopReason = 'end_turn';
+
+    for await (const chunk of this.streamChat(params)) {
+      switch (chunk.type) {
+        case 'text':
+          content += chunk.text ?? '';
+          break;
+        case 'tool_start':
+          if (chunk.toolCall?.id && chunk.toolCall?.name) {
+            toolCalls.push({
+              id: chunk.toolCall.id,
+              name: chunk.toolCall.name,
+              input: chunk.toolCall.input, // May be undefined, updated in tool_end
+            });
+          }
+          break;
+        case 'tool_end':
+          // Update tool call with parsed input (available after arguments accumulated)
+          if (chunk.toolCall?.id && chunk.toolCall?.input !== undefined) {
+            const tc = toolCalls.find((t) => t.id === chunk.toolCall?.id);
+            if (tc) {
+              tc.input = chunk.toolCall.input;
+            }
+          }
+          break;
+        case 'done':
+          usage = chunk.usage ?? usage;
+          stopReason = chunk.stopReason ?? stopReason;
+          break;
+      }
+    }
+
+    return {
+      content,
+      toolCalls,
+      stopReason,
+      usage,
+      model: params.model,
+      provider: 'zhipu',
+    };
+  }
+
+  /**
+   * Send chat message with streaming support
+   * Implements manual tool execution loop with OpenAI-compatible streaming API
+   */
+  async *streamChat(params: ChatParams): AsyncGenerator<ChatStreamChunk, void, unknown> {
+    // Get API key
+    const apiKey = await getProviderApiKey(this.db, 'zhipu');
+    if (!apiKey) {
+      throw new Error(
+        'Zhipu API key not configured. Please set ZHIPU_API_KEY environment variable or configure in Settings > API Keys.'
+      );
+    }
+
+    // Create OpenAI client with Zhipu endpoint
+    const client = new OpenAI({
+      apiKey,
+      baseURL: 'https://api.z.ai/api/paas/v4',
+    });
+
+    // Build tools and executors
+    const { toolExecutors } = buildAgentTools(this.db, this.context);
+
+    // Convert tools to OpenAI format
+    const openaiTools: ChatCompletionTool[] | undefined = params.tools
+      ? params.tools.map(toOpenAITool)
+      : undefined;
+
+    // Convert messages to OpenAI format (handles system prompt)
+    const messages = this.prepareMessages(params);
+
+    // Manual tool execution loop (max 10 turns)
+    const MAX_TURNS = 10;
+    let turnCount = 0;
+
+    while (turnCount < MAX_TURNS) {
+      turnCount++;
+
+      // Create streaming request
+      const stream = await client.chat.completions.create({
+        model: params.model,
+        messages,
+        tools: openaiTools,
+        max_tokens: params.maxTokens,
+        temperature: params.temperature,
+        stop: params.stopSequences,
+        stream: true,
+      });
+
+      // Track accumulated tool calls by index
+      const toolCallsAccum = new Map<number, { id: string; name: string; arguments: string }>();
+      // Track which tool indices have emitted tool_start to avoid duplicates
+      const emittedToolStarts = new Set<number>();
+      let finishReason: string | null = null;
+      let promptTokens = 0;
+      let completionTokens = 0;
+
+      for await (const chunk of stream) {
+        const choice = chunk.choices[0];
+        if (!choice) continue;
+
+        finishReason = choice.finish_reason ?? finishReason;
+        const delta = choice.delta;
+
+        // Stream text content
+        if (delta?.content) {
+          yield { type: 'text', text: delta.content };
+        }
+
+        // Accumulate tool calls (streamed incrementally by index)
+        if (delta?.tool_calls) {
+          for (const tc of delta.tool_calls) {
+            const existing = toolCallsAccum.get(tc.index) ?? {
+              id: '',
+              name: '',
+              arguments: '',
+            };
+            if (tc.id) existing.id = tc.id;
+            if (tc.function?.name) {
+              existing.name = tc.function.name;
+              // Yield tool_start only once per tool (when we first see the name)
+              if (!emittedToolStarts.has(tc.index)) {
+                emittedToolStarts.add(tc.index);
+                yield {
+                  type: 'tool_start',
+                  toolCall: { id: existing.id, name: existing.name },
+                };
+              }
+            }
+            if (tc.function?.arguments) {
+              existing.arguments += tc.function.arguments;
+            }
+            toolCallsAccum.set(tc.index, existing);
+          }
+        }
+
+        // Capture usage from final chunk
+        if (chunk.usage) {
+          promptTokens = chunk.usage.prompt_tokens ?? 0;
+          completionTokens = chunk.usage.completion_tokens ?? 0;
+        }
+      }
+
+      // If no tool calls, we're done
+      if (finishReason !== 'tool_calls' || toolCallsAccum.size === 0) {
+        yield {
+          type: 'done',
+          usage: {
+            inputTokens: promptTokens,
+            outputTokens: completionTokens,
+            totalTokens: promptTokens + completionTokens,
+          },
+          stopReason: mapOpenAIStopReason(finishReason),
+        };
+        return;
+      }
+
+      // Execute tool calls
+      const toolCallsArray = Array.from(toolCallsAccum.values());
+
+      // Add assistant message with tool calls to history
+      messages.push({
+        role: 'assistant',
+        content: null,
+        tool_calls: toolCallsArray.map((tc) => ({
+          id: tc.id,
+          type: 'function' as const,
+          function: { name: tc.name, arguments: tc.arguments },
+        })),
+      });
+
+      // Execute each tool
+      for (const tc of toolCallsArray) {
+        try {
+          const input = JSON.parse(tc.arguments);
+          const normalizedName = tc.name;
+          const executor = toolExecutors[normalizedName];
+
+          if (!executor) {
+            throw new Error(`Unknown tool: ${normalizedName}`);
+          }
+
+          const result = await executor(input);
+
+          // Yield tool_end with parsed input
+          yield { type: 'tool_end', toolCall: { id: tc.id, name: tc.name, input } };
+
+          // Add tool result to messages
+          messages.push({
+            role: 'tool',
+            content: result,
+            tool_call_id: tc.id,
+          });
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : 'Tool execution failed';
+          // Include input even on error (may have been parsed successfully)
+          const parsedInput = (() => {
+            try {
+              return JSON.parse(tc.arguments);
+            } catch {
+              return undefined;
+            }
+          })();
+          yield { type: 'tool_end', toolCall: { id: tc.id, name: tc.name, input: parsedInput } };
+          messages.push({
+            role: 'tool',
+            content: JSON.stringify({ error: errorMessage }),
+            tool_call_id: tc.id,
+          });
+        }
+      }
+      // Continue to next turn
+    }
+
+    // Max turns reached (not token limit, so use end_turn)
+    yield {
+      type: 'done',
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      stopReason: 'end_turn',
+    };
+  }
+
+  /**
+   * Check if provider is configured (has API key)
+   */
+  async isConfigured(): Promise<boolean> {
+    const apiKey = await getProviderApiKey(this.db, 'zhipu');
+    return apiKey !== null;
+  }
+
+  /**
+   * Prepare messages for Zhipu API (OpenAI-compatible)
+   * Handles system prompt by converting to system message
+   */
+  private prepareMessages(params: ChatParams): ChatCompletionMessageParam[] {
+    const messages: ChatCompletionMessageParam[] = [];
+
+    // Add system message if provided
+    if (params.systemPrompt) {
+      messages.push({
+        role: 'system',
+        content: params.systemPrompt,
+      });
+    }
+
+    // Convert normalized messages to OpenAI format
+    const openaiMessages = toOpenAIMessages(params.messages);
+    messages.push(...openaiMessages);
+
+    return messages;
+  }
+}
+
+/**
+ * Factory function to create Zhipu provider instance
+ */
+export function createZhipuProvider(db: Pool, context: ToolContext): ChatProvider {
+  return new ZhipuChatProvider(db, context);
+}

--- a/docs/phases/phase-16/00_PHASE_16_OVERVIEW.md
+++ b/docs/phases/phase-16/00_PHASE_16_OVERVIEW.md
@@ -208,6 +208,25 @@ const result = await query({
 **Skills:** `llm-provider-integration` (see references/google.md, zhipu.md, moonshot.md)
 **Subagents:** `context7-docs-fetcher` (latest SDK docs), `test-writer`, `code-reviewer`
 
+### Phase 16F: Dynamic Tool Registry & Advanced Toolpacks
+**Goal:** Restore full tool parity (22+ tools) and optimize context usage by porting the dynamic registry pattern to the new `ChatProvider` architecture.
+
+**Context:** The old MCP server (Phase 6) had 20+ tools organized in packs (Mobile, Introspection, Graphing) but only exposed a small set of "Gateway" tools initially to save context tokens. The new `claude-agent-sdk` implementation in Phase 16A exposes only the 9 Core tools and lacks this dynamic capability.
+
+**Plan:**
+1.  **Port Advanced Toolpacks**: Move logic from `apps/mcp` to `apps/server/src/agent/tools/`:
+    -   `mobile-core/`: `search_mobile_docs`, `find_code_examples`, `get_feature_recipe`
+    -   `introspection/`: `get_project_tech_stack`, `get_db_schema`, `find_symbol_usages`
+    -   `graphing/`: `graph_expand_context`
+2.  **Implement Server-Side Dynamic Registry**: Create `apps/server/src/services/tool-registry.ts` to manage tool visibility based on session state.
+3.  **Implement Gateway Tools**:
+    -   `discover_tools`: Lists available toolpacks (low token cost).
+    -   `enable_tools`: Dynamically updates the session's enabled tool list.
+4.  **Update Chat Logic**: Refactor `agent.ts` to re-generate the `tools` array passed to the provider whenever `enable_tools` is called, allowing the agent to "expand" its capabilities mid-conversation.
+
+**Skills:** `synthesis-architecture`, `backend-development`, `agentic-design`
+**Subagents:** `Plan` (registry design), `test-writer` (dynamic flow tests)
+
 ### Cross-Phase Resources
 **Throughout all phases:**
 - `git-github-workflow-manager` - PR creation and management
@@ -338,6 +357,7 @@ Each sub-phase (16A, 16B, etc.) gets its own commits. Group related changes:
 | 16C: Streaming & UI | 2-3 commits (backend SSE + frontend) | Single PR |
 | 16D: Tool Adapters | 1-2 commits (adapters + tests) | Single PR |
 | 16E: Additional Providers | 1 commit per provider | Single PR |
+| 16F: Dynamic Tools | 3-4 commits (registry + gateway tools) | Single PR |
 
 ### Workflow Steps
 

--- a/docs/phases/phase-16/PHASE_16_MULTI-PROVIDER-SUMMARY.md
+++ b/docs/phases/phase-16/PHASE_16_MULTI-PROVIDER-SUMMARY.md
@@ -4,7 +4,7 @@
 
 This document tracks the implementation progress of Phase 16: Multi-Provider Chat & UI Improvements.
 
-**Status:** Phases 16A-16D MERGED, Phase 16E NOT STARTED
+**Status:** Phases 16A-16E IMPLEMENTED (16E pending commit)
 
 ---
 
@@ -354,19 +354,108 @@ async chat(params: ChatParams): Promise<ChatResponse> {
 
 ---
 
-## Phase 16E: Additional Providers - NOT STARTED
+## Phase 16E: Additional Providers - IMPLEMENTED
 
-**Planned work:**
-1. Add Google AI provider
-2. Add OpenAI-compatible provider base
-3. Add GLM 4 (Z.AI) support
-4. Add Kimi (Moonshot) support
+**Status:** IMPLEMENTED (pending commit)
+**Branch:** `feature/phase-16-multi-provider-chat`
+**Date:** 2025-12-06
+
+### Overview
+
+Added three new chat providers: Google Gemini, Z.AI (Zhipu GLM-4), and Moonshot (Kimi K2).
+
+### Files Created
+
+| File | Description |
+|------|-------------|
+| `apps/server/src/services/chat-providers/google.ts` | Google Gemini provider with native SDK |
+| `apps/server/src/services/chat-providers/zhipu.ts` | Z.AI GLM-4 provider (OpenAI-compatible) |
+| `apps/server/src/services/chat-providers/moonshot.ts` | Moonshot Kimi provider with thinking mode |
+| `apps/server/src/services/chat-providers/openai-compatible.ts` | Base utilities for OpenAI-compatible providers |
+| `apps/server/src/services/chat-providers/__tests__/google.test.ts` | 30 tests |
+| `apps/server/src/services/chat-providers/__tests__/zhipu.test.ts` | 26 tests |
+| `apps/server/src/services/chat-providers/__tests__/moonshot.test.ts` | 29 tests |
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `apps/server/src/services/chat-providers/index.ts` | Added imports and registration for Google, Zhipu, Moonshot |
+| `apps/server/package.json` | Added `@google/generative-ai` dependency |
+
+### Provider Capabilities
+
+| Provider | Tool Support | Streaming | Vision | Max Context | Base URL |
+|----------|--------------|-----------|--------|-------------|----------|
+| Google | ✅ Manual loop | ✅ | ✅ | 1M | Native SDK |
+| Z.AI (Zhipu) | ✅ Manual loop | ✅ | ❌ | 128K | `api.z.ai/api/paas/v4` |
+| Moonshot | ✅ Manual loop | ✅ | ❌ | 256K | `api.moonshot.cn/v1` |
+
+### Models Supported
+
+**Google Gemini:**
+- gemini-3-pro-preview
+- gemini-2.5-flash
+- gemini-2.5-flash-lite
+- gemini-2.5-pro
+- gemini-3-pro-image-preview
+
+**Z.AI (Zhipu):**
+- GLM-4.6
+- GLM-4.5-Air
+
+**Moonshot (Kimi):**
+- kimi-k2-0905-preview
+- kimi-k2-thinking (with thinking mode)
+- kimi-k2-thinking-turbo (with thinking mode)
+
+### Implementation Details
+
+#### Google Provider
+- Uses native `@google/generative-ai` SDK
+- Converts JSON Schema types to Google `SchemaType` enum
+- System prompts via `systemInstruction` parameter
+- Function calls use `functionDeclarations` format
+
+#### Z.AI Provider
+- OpenAI-compatible API at `https://api.z.ai/api/paas/v4`
+- Uses standard OpenAI SDK with custom `baseURL`
+- Manual 10-turn tool execution loop
+
+#### Moonshot Provider
+- OpenAI-compatible API at `https://api.moonshot.cn/v1`
+- Special **thinking mode** for reasoning models
+- Enabled via `extra_body: { thinking: { type: "enabled", max_tokens: 4096 } }`
+- Auto-detected from model name containing "thinking"
+
+### Environment Variables
+
+| Variable | Provider | Purpose |
+|----------|----------|---------|
+| `GOOGLE_API_KEY` | Google | Gemini API key |
+| `ZHIPU_API_KEY` | Z.AI | GLM API key |
+| `MOONSHOT_API_KEY` | Moonshot | Kimi API key |
+
+### Verification
+
+| Check | Status |
+|-------|--------|
+| `pnpm --filter @synthesis/server typecheck` | ✅ PASS |
+| google.test.ts (30 tests) | ✅ PASS |
+| zhipu.test.ts (26 tests) | ✅ PASS |
+| moonshot.test.ts (29 tests) | ✅ PASS |
+| **Total: 85 new tests** | ✅ ALL PASS |
+
+### Dependencies Added
+
+- `@google/generative-ai` - Google Generative AI SDK for Gemini models
 
 ---
 
-## Dependencies Added
+## All Dependencies Added
 
 - `@anthropic-ai/claude-agent-sdk` - Claude Agent SDK for agentic workflows
+- `@google/generative-ai` - Google Generative AI SDK for Gemini models
 
 ---
 
@@ -387,4 +476,5 @@ async chat(params: ChatParams): Promise<ChatResponse> {
 4. ~~Implement Phase 16D: Tool Adapters~~ ✅ MERGED (with 16B)
 5. ~~Merge PR #150 to develop~~ ✅ MERGED
 6. ~~Phase 16C: Streaming & UI~~ ✅ MERGED (PR #151)
-7. **BEGIN Phase 16E: Additional Providers (Google, GLM, Kimi)**
+7. ~~Phase 16E: Additional Providers (Google, GLM, Kimi)~~ ✅ IMPLEMENTED (pending commit)
+8. Create PR for Phase 16E and merge to develop

--- a/docs/phases/phase-16/PHASE_16_MULTI-PROVIDER-SUMMARY.md
+++ b/docs/phases/phase-16/PHASE_16_MULTI-PROVIDER-SUMMARY.md
@@ -4,11 +4,13 @@
 
 This document tracks the implementation progress of Phase 16: Multi-Provider Chat & UI Improvements.
 
+**Status:** Phases 16A-16D MERGED, Phase 16E NOT STARTED
+
 ---
 
-## Phase 16A: Claude Agent SDK Migration - COMPLETED
+## Phase 16A: Claude Agent SDK Migration - MERGED
 
-**Status:** COMPLETED
+**Status:** MERGED
 **Branch:** `feature/phase-16-multi-provider-chat`
 **Date:** 2025-12-06
 
@@ -20,11 +22,13 @@ This document tracks the implementation progress of Phase 16: Multi-Provider Cha
    - Added tool format adapters
    - Created provider registry pattern
 
-2. **Pending commit** - `feat(phase-16a): migrate agent to Claude Agent SDK query()`
+2. **90b9ee1** - `feat(phase-16a): migrate agent to Claude Agent SDK query()`
    - Replaced manual Anthropic SDK 10-turn loop with SDK's `query()` function
    - Added `buildAgentMcpServer()` with 9 MCP tools
    - Kept legacy `buildAgentTools()` for backward compatibility
    - Updated tests with SDK mocks and MCP format validation
+
+3. **cca2125** - `fix(phase-16a): use injected db pool in summarize_document MCP tool`
 
 ### Files Modified
 
@@ -115,12 +119,12 @@ See: [Issue #20](https://github.com/anthropics/claude-agent-sdk-typescript/issue
 
 ---
 
-## Phase 16B+D: Multi-Provider Chat with Tool Support - COMPLETED
+## Phase 16B+D: Multi-Provider Chat with Tool Support - MERGED
 
-**Status:** COMPLETED
+**Status:** MERGED
 **Branch:** `feature/phase-16-multi-provider-chat`
 **Date:** 2025-12-06
-**PR:** [#150](https://github.com/Beaulewis1977/synthesis/pull/150)
+**PR:** [#150](https://github.com/Beaulewis1977/synthesis/pull/150) (merged)
 
 ### Commits
 
@@ -137,6 +141,8 @@ See: [Issue #20](https://github.com/anthropics/claude-agent-sdk-typescript/issue
    - openai.test.ts: 25 tests (tool execution loop, max turns, stop reasons)
    - ollama.test.ts: 16 tests (basic chat, message conversion, configuration)
    - Total: 55 tests, all passing
+
+3. **cc76258** - `fix(phase-16b): address CodeRabbit review feedback`
 
 ### Files Created/Modified
 
@@ -217,11 +223,53 @@ while (turnCount < MAX_TURNS) {
 
 ---
 
-## Phase 16C: Streaming & UI - COMPLETED
+## Phase 16C: Streaming & UI - MERGED
 
-**Status:** COMPLETED
+**Status:** MERGED
 **Branch:** `feature/phase-16-multi-provider-chat`
 **Date:** 2025-12-06
+**PR:** [#151](https://github.com/Beaulewis1977/synthesis/pull/151) (merged)
+
+### Commits
+
+1. **c0d16be** - `feat(phase-16c): implement SSE streaming for real-time chat responses`
+   - Added `streamChat()` to all providers (Anthropic, OpenAI, Ollama)
+   - Refactored `chat()` to delegate to `streamChat()` internally
+   - Created SSE endpoint `/api/agent/chat/stream`
+   - Created `useStreamingChat` hook for SSE consumption
+   - Created `StreamingMessage` component with cursor animation
+   - Updated ChatPage to use streaming by default
+
+2. **0a52d1e** - `fix(phase-16c): address PR #151 review feedback`
+   - `adapters.ts`: Changed `content: ''` to `content: null` for assistant tool_calls (OpenAI spec)
+   - `useStreamingChat.ts`: Removed duplicate `onComplete` call, fixed dependency array
+
+3. **f8fa387** - `fix(phase-16c): address additional PR #151 review feedback`
+   - `agent-stream.ts`: Don't persist partial messages on stream error
+   - `agent-stream.ts`: Remove unused `_fullContent` parameter
+   - `agent-stream.ts`: Convert dynamic import to static import
+   - `ChatPage.tsx`: Include current user message in history
+   - `useStreamingChat.ts`: Defensive tool matching
+   - `StreamingMessage.tsx`: Accessibility improvements (aria-live, aria-hidden, aria-labels)
+
+4. **1196160** - `fix(phase-16c): add reply.hijack() and remove duplicate end() call`
+   - Added `reply.hijack()` for proper Fastify SSE handling
+   - Removed duplicate `reply.raw.end()` call
+
+5. **460e85a** - `fix(phase-16c): address remaining PR #151 review feedback`
+   - `useStreamingChat.ts`: Add useEffect cleanup on unmount
+   - `useStreamingChat.ts`: Use optionsRef to avoid re-renders
+   - `useStreamingChat.ts`: Clear abortControllerRef after abort
+   - `useStreamingChat.ts`: Pass toolCalls to onComplete (avoid stale closure)
+   - `ChatPage.tsx`: Use toolCalls parameter from onComplete
+   - `agent-stream.ts`: Rename `tc` to `toolCall` for consistency
+   - `agent-stream.ts`: Remove redundant `streamSuccess` variable
+   - `openai.ts`: Track emitted tool_start events to avoid duplicates
+
+6. **5347e39** - `fix(phase-16c): fix openai.ts tool call input and stopReason bugs`
+   - Include parsed `input` in `tool_end` events
+   - Add `tool_end` handler in `chat()` to update tool call inputs
+   - Fix `stopReason` from `'max_tokens'` to `'end_turn'` when max turns reached
 
 ### Implementation
 
@@ -232,13 +280,15 @@ while (turnCount < MAX_TURNS) {
 
 2. **Backend: SSE endpoint `/api/agent/chat/stream`**
    - New route in `apps/server/src/routes/agent-stream.ts`
+   - Uses `reply.hijack()` for proper Fastify SSE handling
    - Streams `ChatStreamChunk` events as SSE
    - Event types: `token`, `tool_start`, `tool_end`, `done`, `error`
-   - Session persistence on stream completion
+   - Session persistence on stream completion (only on success)
 
 3. **Frontend: Streaming hook and components**
-   - `useStreamingChat` hook for SSE consumption
+   - `useStreamingChat` hook for SSE consumption with proper cleanup
    - `StreamingMessage` component with cursor animation and tool progress
+   - Accessibility: aria-live, aria-hidden, aria-labels
    - ChatPage updated to use streaming by default
 
 ### Files Created/Modified
@@ -246,13 +296,14 @@ while (turnCount < MAX_TURNS) {
 | File | Changes |
 |------|---------|
 | `apps/server/src/services/chat-providers/anthropic.ts` | Added `streamChat()`, refactored `chat()` |
-| `apps/server/src/services/chat-providers/openai.ts` | Added `streamChat()` with streaming tool loop |
+| `apps/server/src/services/chat-providers/openai.ts` | Added `streamChat()` with streaming tool loop, tool input in events |
 | `apps/server/src/services/chat-providers/ollama.ts` | Added `streamChat()` |
-| `apps/server/src/routes/agent-stream.ts` | NEW: SSE streaming endpoint |
+| `apps/server/src/services/chat-providers/adapters.ts` | Fixed `content: null` for assistant tool_calls |
+| `apps/server/src/routes/agent-stream.ts` | NEW: SSE streaming endpoint with `reply.hijack()` |
 | `apps/server/src/index.ts` | Registered `agentStreamRoutes` |
-| `apps/web/src/hooks/useStreamingChat.ts` | NEW: SSE client hook |
-| `apps/web/src/components/StreamingMessage.tsx` | NEW: Streaming message UI |
-| `apps/web/src/pages/ChatPage.tsx` | Updated to use streaming |
+| `apps/web/src/hooks/useStreamingChat.ts` | NEW: SSE client hook with cleanup and optionsRef |
+| `apps/web/src/components/StreamingMessage.tsx` | NEW: Streaming message UI with accessibility |
+| `apps/web/src/pages/ChatPage.tsx` | Updated to use streaming with toolCalls parameter |
 
 ### SSE Event Format
 
@@ -330,10 +381,10 @@ async chat(params: ChatParams): Promise<ChatResponse> {
 
 ## Next Steps
 
-1. ~~Commit the pending Phase 16A changes~~ ✅ DONE
-2. ~~Create PR for Phase 16A~~ ✅ DONE
-3. ~~Begin Phase 16B: Multi-Provider Chat implementation~~ ✅ DONE
-4. ~~Implement Phase 16D: Tool Adapters~~ ✅ DONE (merged with 16B)
-5. Merge PR #150 to develop
-6. ~~Phase 16C: Streaming & UI~~ ✅ DONE
-7. Begin Phase 16E: Additional Providers (Google, GLM, Kimi)
+1. ~~Commit the pending Phase 16A changes~~ ✅ MERGED
+2. ~~Create PR for Phase 16A~~ ✅ MERGED
+3. ~~Begin Phase 16B: Multi-Provider Chat implementation~~ ✅ MERGED
+4. ~~Implement Phase 16D: Tool Adapters~~ ✅ MERGED (with 16B)
+5. ~~Merge PR #150 to develop~~ ✅ MERGED
+6. ~~Phase 16C: Streaming & UI~~ ✅ MERGED (PR #151)
+7. **BEGIN Phase 16E: Additional Providers (Google, GLM, Kimi)**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       '@fastify/multipart':
         specifier: ^8.3.0
         version: 8.3.1
+      '@google/generative-ai':
+        specifier: ^0.24.1
+        version: 0.24.1
       '@synthesis/db':
         specifier: workspace:*
         version: link:../../packages/db
@@ -1181,6 +1184,10 @@ packages:
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+
+  '@google/generative-ai@0.24.1':
+    resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
+    engines: {node: '>=18.0.0'}
 
   '@huggingface/jinja@0.2.2':
     resolution: {integrity: sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==}
@@ -6329,6 +6336,8 @@ snapshots:
       stream-wormhole: 1.1.0
 
   '@gar/promisify@1.1.3': {}
+
+  '@google/generative-ai@0.24.1': {}
 
   '@huggingface/jinja@0.2.2': {}
 


### PR DESCRIPTION
## Summary

Phase 16E: Additional Providers implementation for the multi-provider chat system.

### New Providers Added

| Provider | API | Models | Context | Features |
|----------|-----|--------|---------|----------|
| **Google Gemini** | Native SDK | gemini-3-pro, gemini-2.5-flash/pro | 1M tokens | Vision, Tools, Streaming |
| **Z.AI (Zhipu)** | OpenAI-compatible | GLM-4.6, GLM-4.5-Air | 128K tokens | Tools, Streaming |
| **Moonshot (Kimi)** | OpenAI-compatible | kimi-k2-0905-preview, kimi-k2-thinking* | 256K tokens | Tools, Streaming, Thinking mode |

### Key Implementation Details

- **Manual 10-turn tool execution loop** for all providers (consistent with OpenAI/Anthropic)
- **Streaming support** via `streamChat()` async generators
- **Moonshot thinking mode** auto-detected from model name containing "thinking"
- **Google SchemaType conversion** for tool definitions (JSON Schema → Google SDK format)

### Test Fixes

Fixed pre-existing test issues caused by Phase 16C streaming refactor:
- Updated OpenAI/Ollama tests to use streaming mock format (async generators)
- Added `fallbackText` field to `ChatStreamChunk` type for Anthropic SDK compatibility

### Test Results

| Test File | Tests | Status |
|-----------|-------|--------|
| google.test.ts | 30 | ✅ PASS |
| zhipu.test.ts | 26 | ✅ PASS |
| moonshot.test.ts | 29 | ✅ PASS |
| anthropic.test.ts | 14 | ✅ PASS |
| openai.test.ts | 25 | ✅ PASS |
| ollama.test.ts | 16 | ✅ PASS |
| **Total** | **140** | ✅ **ALL PASS** |

### Environment Variables

| Variable | Provider |
|----------|----------|
| `GOOGLE_API_KEY` | Google Gemini |
| `ZHIPU_API_KEY` | Z.AI (Zhipu) |
| `MOONSHOT_API_KEY` | Moonshot (Kimi) |

### Files Changed

**New files (7):**
- `apps/server/src/services/chat-providers/google.ts`
- `apps/server/src/services/chat-providers/zhipu.ts`
- `apps/server/src/services/chat-providers/moonshot.ts`
- `apps/server/src/services/chat-providers/openai-compatible.ts`
- `apps/server/src/services/chat-providers/__tests__/google.test.ts`
- `apps/server/src/services/chat-providers/__tests__/zhipu.test.ts`
- `apps/server/src/services/chat-providers/__tests__/moonshot.test.ts`

**Modified files (9):**
- Provider registry, types, Anthropic provider (fallback), test fixes, docs

## Test plan

- [x] `pnpm typecheck` passes
- [x] All 140 chat provider tests pass
- [x] New providers registered correctly in index.ts
- [ ] Manual testing with real API keys (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Google Gemini as a new chat provider with streaming and tool execution capabilities
  * Added support for Moonshot (Kimi) as a new chat provider with thinking mode support
  * Added support for Z.AI (Zhipu) as a new chat provider with full streaming integration
  * Enhanced content preservation with fallback text handling

* **Tests**
  * Added comprehensive test coverage for all new chat providers

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->