### PR TITLE
feat(chat): add stop button, rename, batch delete, and resizable sidebar

### DIFF
--- a/apps/server/src/routes/chat.ts
+++ b/apps/server/src/routes/chat.ts
@@ -8,6 +8,7 @@ import {
   addChatMessage,
   createChatSession,
   deleteChatSession,
+  deleteChatSessions,
   getChatMessages,
   getChatSession,
   listChatSessions,
@@ -41,6 +42,11 @@ const AddMessageSchema = z.object({
 });
 
 const uuidSchema = z.string().uuid();
+
+// Schema for batch delete
+const BatchDeleteSchema = z.object({
+  session_ids: z.array(z.string().uuid()).min(1).max(100),
+});
 
 export const chatRoutes: FastifyPluginAsync = async (fastify) => {
   // List chat sessions for a collection
@@ -125,6 +131,25 @@ export const chatRoutes: FastifyPluginAsync = async (fastify) => {
     } catch (error) {
       fastify.log.error(error, 'Failed to delete chat session');
       return reply.code(500).send({ error: 'Failed to delete chat session' });
+    }
+  });
+
+  // Batch delete chat sessions
+  fastify.post('/api/chats/batch/delete', async (request, reply) => {
+    const validation = BatchDeleteSchema.safeParse(request.body);
+    if (!validation.success) {
+      return reply.code(400).send({
+        error: 'Invalid request',
+        details: validation.error.issues,
+      });
+    }
+
+    try {
+      const deletedCount = await deleteChatSessions(validation.data.session_ids);
+      return reply.send({ deleted: deletedCount });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to batch delete chat sessions');
+      return reply.code(500).send({ error: 'Failed to batch delete chat sessions' });
     }
   });
 

--- a/apps/web/src/components/ChatHistorySidebar.tsx
+++ b/apps/web/src/components/ChatHistorySidebar.tsx
@@ -1,6 +1,6 @@
 import { format } from 'date-fns';
-import { MessageSquare, Plus, Trash2 } from 'lucide-react';
-import { useState } from 'react';
+import { MessageSquare, Pencil, Plus, Trash2 } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 import type { ChatSession } from '../types';
 
 interface ChatHistorySidebarProps {
@@ -9,7 +9,10 @@ interface ChatHistorySidebarProps {
   onSelectSession: (sessionId: string) => void;
   onNewChat: () => void;
   onDeleteSession?: (sessionId: string) => void;
+  onRenameSession?: (sessionId: string, newTitle: string) => void;
+  onBatchDeleteSessions?: (sessionIds: string[]) => void;
   className?: string;
+  style?: React.CSSProperties;
 }
 
 export function ChatHistorySidebar({
@@ -18,9 +21,25 @@ export function ChatHistorySidebar({
   onSelectSession,
   onNewChat,
   onDeleteSession,
+  onRenameSession,
+  onBatchDeleteSessions,
   className = '',
+  style,
 }: ChatHistorySidebarProps) {
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editTitle, setEditTitle] = useState('');
+  const [isSelectionMode, setIsSelectionMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const editInputRef = useRef<HTMLInputElement>(null);
+
+  // Focus input when editing starts
+  useEffect(() => {
+    if (editingId && editInputRef.current) {
+      editInputRef.current.focus();
+      editInputRef.current.select();
+    }
+  }, [editingId]);
 
   const handleDeleteClick = (e: React.MouseEvent, sessionId: string) => {
     e.stopPropagation();
@@ -38,8 +57,56 @@ export function ChatHistorySidebar({
     setDeleteConfirmId(null);
   };
 
+  const handleEditClick = (e: React.MouseEvent, session: ChatSession) => {
+    e.stopPropagation();
+    setEditingId(session.id);
+    setEditTitle(session.title);
+  };
+
+  const handleEditSave = (sessionId: string) => {
+    const trimmed = editTitle.trim();
+    if (trimmed && trimmed !== sessions.find((s) => s.id === sessionId)?.title) {
+      onRenameSession?.(sessionId, trimmed);
+    }
+    setEditingId(null);
+  };
+
+  const handleEditKeyDown = (e: React.KeyboardEvent, sessionId: string) => {
+    if (e.key === 'Enter') {
+      handleEditSave(sessionId);
+    } else if (e.key === 'Escape') {
+      setEditingId(null);
+    }
+  };
+
+  const handleCheckboxChange = (sessionId: string, checked: boolean) => {
+    const newSet = new Set(selectedIds);
+    if (checked) {
+      newSet.add(sessionId);
+    } else {
+      newSet.delete(sessionId);
+    }
+    setSelectedIds(newSet);
+  };
+
+  const handleBatchDelete = () => {
+    if (selectedIds.size > 0) {
+      onBatchDeleteSessions?.(Array.from(selectedIds));
+      setSelectedIds(new Set());
+      setIsSelectionMode(false);
+    }
+  };
+
+  const toggleSelectionMode = () => {
+    setIsSelectionMode(!isSelectionMode);
+    setSelectedIds(new Set());
+  };
+
   return (
-    <div className={`flex flex-col h-full bg-bg-secondary border-r border-border ${className}`}>
+    <div
+      className={`flex flex-col h-full bg-bg-secondary border-r border-border ${className}`}
+      style={style}
+    >
       <div className="p-md border-b border-border">
         <button
           type="button"
@@ -50,6 +117,22 @@ export function ChatHistorySidebar({
           New Chat
         </button>
       </div>
+
+      {/* Selection mode toggle */}
+      {sessions.length > 0 && onBatchDeleteSessions && (
+        <div className="px-md py-sm border-b border-border flex items-center justify-between">
+          <span className="text-xs text-text-secondary">
+            {isSelectionMode ? `${selectedIds.size} selected` : `${sessions.length} chats`}
+          </span>
+          <button
+            type="button"
+            onClick={toggleSelectionMode}
+            className="text-xs text-accent hover:underline"
+          >
+            {isSelectionMode ? 'Cancel' : 'Manage'}
+          </button>
+        </div>
+      )}
 
       <div className="flex-1 overflow-y-auto p-sm space-y-xs">
         {sessions.length === 0 ? (
@@ -82,42 +165,98 @@ export function ChatHistorySidebar({
               ) : (
                 <button
                   type="button"
-                  onClick={() => onSelectSession(session.id)}
-                  className={`w-full text-left p-sm rounded-md transition-colors flex items-start gap-sm ${
+                  onClick={() => !isSelectionMode && onSelectSession(session.id)}
+                  className={`w-full text-left p-sm rounded-md transition-colors flex items-start gap-sm cursor-pointer ${
                     currentSessionId === session.id
                       ? 'bg-accent/10 text-accent'
                       : 'hover:bg-bg-hover text-text-primary'
                   }`}
                 >
-                  <MessageSquare
-                    size={16}
-                    className={`mt-1 flex-shrink-0 ${
-                      currentSessionId === session.id ? 'text-accent' : 'text-text-secondary'
-                    }`}
-                  />
+                  {/* Selection checkbox */}
+                  {isSelectionMode && (
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.has(session.id)}
+                      onChange={(e) => handleCheckboxChange(session.id, e.target.checked)}
+                      onClick={(e) => e.stopPropagation()}
+                      className="mt-1 flex-shrink-0"
+                    />
+                  )}
+
+                  {!isSelectionMode && (
+                    <MessageSquare
+                      size={16}
+                      className={`mt-1 flex-shrink-0 ${
+                        currentSessionId === session.id ? 'text-accent' : 'text-text-secondary'
+                      }`}
+                    />
+                  )}
+
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium text-sm truncate">{session.title}</p>
-                    <p className="text-xs text-text-secondary truncate">
-                      {session.updated_at
-                        ? (() => {
-                            try {
-                              return format(new Date(session.updated_at), 'MMM d, h:mm a');
-                            } catch {
-                              return 'Unknown date';
-                            }
-                          })()
-                        : 'Unknown date'}
-                    </p>
+                    {editingId === session.id ? (
+                      <input
+                        ref={editInputRef}
+                        type="text"
+                        value={editTitle}
+                        onChange={(e) => setEditTitle(e.target.value)}
+                        onBlur={() => handleEditSave(session.id)}
+                        onKeyDown={(e) => handleEditKeyDown(e, session.id)}
+                        onClick={(e) => e.stopPropagation()}
+                        className="w-full px-xs py-0.5 text-sm rounded border border-accent bg-white focus:outline-none focus:ring-1 focus:ring-accent"
+                      />
+                    ) : (
+                      <p className="font-medium text-sm truncate">{session.title}</p>
+                    )}
+                    <div className="flex items-center gap-xs text-xs text-text-secondary">
+                      <span className="truncate">
+                        {session.updated_at
+                          ? (() => {
+                              try {
+                                return format(new Date(session.updated_at), 'MMM d, h:mm a');
+                              } catch {
+                                return 'Unknown date';
+                              }
+                            })()
+                          : 'Unknown date'}
+                      </span>
+                      {session.model && (
+                        <>
+                          <span>•</span>
+                          <span
+                            className="truncate max-w-[80px]"
+                            title={`${session.provider || ''}/${session.model}`}
+                          >
+                            {session.model.split('/').pop() || session.model}
+                          </span>
+                        </>
+                      )}
+                    </div>
                   </div>
-                  {onDeleteSession && (
-                    <button
-                      type="button"
-                      onClick={(e) => handleDeleteClick(e, session.id)}
-                      className="opacity-0 group-hover:opacity-100 p-xs rounded hover:bg-red-100 text-text-secondary hover:text-red-600 transition-all"
-                      title="Delete session"
-                    >
-                      <Trash2 size={14} />
-                    </button>
+
+                  {/* Action buttons (only show when not in selection mode) */}
+                  {!isSelectionMode && (
+                    <div className="flex gap-xs opacity-0 group-hover:opacity-100 transition-opacity">
+                      {onRenameSession && (
+                        <button
+                          type="button"
+                          onClick={(e) => handleEditClick(e, session)}
+                          className="p-xs rounded hover:bg-bg-hover text-text-secondary hover:text-accent"
+                          title="Rename"
+                        >
+                          <Pencil size={14} />
+                        </button>
+                      )}
+                      {onDeleteSession && (
+                        <button
+                          type="button"
+                          onClick={(e) => handleDeleteClick(e, session.id)}
+                          className="p-xs rounded hover:bg-red-100 text-text-secondary hover:text-red-600"
+                          title="Delete session"
+                        >
+                          <Trash2 size={14} />
+                        </button>
+                      )}
+                    </div>
                   )}
                 </button>
               )}
@@ -125,6 +264,19 @@ export function ChatHistorySidebar({
           ))
         )}
       </div>
+
+      {/* Batch delete button */}
+      {isSelectionMode && selectedIds.size > 0 && (
+        <div className="p-sm border-t border-border">
+          <button
+            type="button"
+            onClick={handleBatchDelete}
+            className="w-full py-sm text-sm bg-red-600 text-white rounded hover:bg-red-700 transition-colors"
+          >
+            Delete Selected ({selectedIds.size})
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -296,6 +296,17 @@ class ApiClient {
   }
 
   /**
+   * Batch delete multiple chat sessions.
+   * Uses CASCADE - all messages are automatically deleted.
+   */
+  async batchDeleteChatSessions(sessionIds: string[]): Promise<{ deleted: number }> {
+    return this.request<{ deleted: number }>('/api/chats/batch/delete', {
+      method: 'POST',
+      body: JSON.stringify({ session_ids: sessionIds }),
+    });
+  }
+
+  /**
    * Update a chat session title.
    * Phase 16 feature - persistent chat history.
    */

--- a/apps/web/src/pages/ChatPage.tsx
+++ b/apps/web/src/pages/ChatPage.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { AlertCircle, Menu } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { AlertCircle, GripVertical, Menu, Square } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { ChatHistorySidebar } from '../components/ChatHistorySidebar';
 import { ChatMessage } from '../components/ChatMessage';
@@ -27,8 +27,56 @@ export function ChatPage() {
   const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
   const [selectedModel, setSelectedModel] = useState<string | null>(null);
 
+  // Resizable sidebar
+  const [sidebarWidth, setSidebarWidth] = useState(() => {
+    const saved = localStorage.getItem('chat-sidebar-width');
+    return saved ? Number(saved) : 256; // Default 256px (w-64)
+  });
+  const [isResizing, setIsResizing] = useState(false);
+  const sidebarRef = useRef<HTMLDivElement>(null);
+
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Sidebar resize handlers
+  const startResizing = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsResizing(true);
+  }, []);
+
+  const stopResizing = useCallback(() => {
+    setIsResizing(false);
+  }, []);
+
+  const resize = useCallback(
+    (e: MouseEvent) => {
+      if (isResizing && sidebarRef.current) {
+        const newWidth = e.clientX - sidebarRef.current.getBoundingClientRect().left;
+        // Clamp between 200px and 500px
+        const clampedWidth = Math.max(200, Math.min(500, newWidth));
+        setSidebarWidth(clampedWidth);
+        localStorage.setItem('chat-sidebar-width', String(clampedWidth));
+      }
+    },
+    [isResizing]
+  );
+
+  useEffect(() => {
+    if (isResizing) {
+      window.addEventListener('mousemove', resize);
+      window.addEventListener('mouseup', stopResizing);
+      // Prevent text selection while dragging
+      document.body.style.userSelect = 'none';
+      document.body.style.cursor = 'col-resize';
+    }
+
+    return () => {
+      window.removeEventListener('mousemove', resize);
+      window.removeEventListener('mouseup', stopResizing);
+      document.body.style.userSelect = '';
+      document.body.style.cursor = '';
+    };
+  }, [isResizing, resize, stopResizing]);
 
   // Streaming chat hook
   const {
@@ -36,6 +84,7 @@ export function ChatPage() {
     content: streamingContent,
     toolCalls: streamingToolCalls,
     streamChat,
+    cancelStream,
   } = useStreamingChat({
     onComplete: (content, _usage, toolCalls) => {
       // Add completed streaming message to messages array
@@ -293,15 +342,37 @@ export function ChatPage() {
     setSelectedModel(model || null);
   };
 
-  const isLoading = chatMutation.isPending || isStreaming;
+  const handleRenameSession = async (id: string, newTitle: string) => {
+    try {
+      await apiClient.updateChatSessionTitle(id, newTitle);
+      refetchSessions();
+    } catch (error) {
+      console.error('Failed to rename session:', error);
+    }
+  };
+
+  const handleBatchDeleteSessions = async (sessionIds: string[]) => {
+    try {
+      await apiClient.batchDeleteChatSessions(sessionIds);
+      // If we deleted the current session, clear it
+      if (sessionId && sessionIds.includes(sessionId)) {
+        handleNewChat();
+      }
+      refetchSessions();
+    } catch (error) {
+      console.error('Failed to batch delete sessions:', error);
+    }
+  };
 
   return (
     <div className="h-[calc(100vh-120px)] flex">
       {/* Sidebar */}
       <div
+        ref={sidebarRef}
+        style={{ width: isSidebarOpen ? sidebarWidth : 0 }}
         className={`
-          ${isSidebarOpen ? 'w-64' : 'w-0'} 
-          transition-all duration-300 ease-in-out overflow-hidden border-r border-border bg-bg-secondary flex-shrink-0
+          ${isResizing ? '' : 'transition-all duration-300 ease-in-out'}
+          overflow-hidden border-r border-border bg-bg-secondary flex-shrink-0 relative
         `}
       >
         <ChatHistorySidebar
@@ -310,8 +381,26 @@ export function ChatPage() {
           onSelectSession={handleSelectSession}
           onNewChat={handleNewChat}
           onDeleteSession={handleDeleteSession}
-          className="h-full w-64"
+          onRenameSession={handleRenameSession}
+          onBatchDeleteSessions={handleBatchDeleteSessions}
+          className="h-full"
+          style={{ width: sidebarWidth }}
         />
+
+        {/* Resize handle */}
+        {isSidebarOpen && (
+          <div
+            onMouseDown={startResizing}
+            className={`absolute top-0 right-0 w-1 h-full cursor-col-resize hover:bg-accent/50 transition-colors group flex items-center justify-center ${
+              isResizing ? 'bg-accent' : ''
+            }`}
+            title="Drag to resize"
+          >
+            <div className="absolute right-0 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity">
+              <GripVertical size={12} className="text-text-secondary" />
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Main Content */}
@@ -479,13 +568,21 @@ export function ChatPage() {
                   // Don't disable input while loading to allow queueing/optimistic updates
                   // disabled={isLoading}
                 />
-                <button
-                  type="submit"
-                  className="btn btn-primary"
-                  disabled={!inputValue.trim()} // Allow sending even if loading (queueing handled by mutation chain ideally or just optimistic)
-                >
-                  {isLoading ? 'Sending...' : 'Send →'}
-                </button>
+                {isStreaming ? (
+                  <button
+                    type="button"
+                    onClick={cancelStream}
+                    className="btn bg-red-600 text-white hover:bg-red-700 flex items-center gap-xs"
+                    title="Stop generation"
+                  >
+                    <Square size={16} />
+                    Stop
+                  </button>
+                ) : (
+                  <button type="submit" className="btn btn-primary" disabled={!inputValue.trim()}>
+                    Send →
+                  </button>
+                )}
               </form>
             </div>
           </div>

--- a/packages/db/src/queries.ts
+++ b/packages/db/src/queries.ts
@@ -483,6 +483,19 @@ export async function deleteChatSession(sessionId: string): Promise<void> {
 }
 
 /**
+ * Deletes multiple chat sessions and all their messages (cascade).
+ * @param sessionIds Array of chat session IDs to delete.
+ * @returns Number of sessions deleted.
+ */
+export async function deleteChatSessions(sessionIds: string[]): Promise<number> {
+  if (sessionIds.length === 0) return 0;
+
+  const placeholders = sessionIds.map((_, i) => `$${i + 1}`).join(', ');
+  const result = await query(`DELETE FROM chat_sessions WHERE id IN (${placeholders})`, sessionIds);
+  return result.rowCount ?? 0;
+}
+
+/**
  * Updates the title of a chat session.
  * @param sessionId The chat session ID.
  * @param title The new title.


### PR DESCRIPTION
## Summary

- **Stop Button**: Halts streaming mid-generation using AbortController. Red button replaces Send while streaming.
- **Inline Rename**: Pencil icon on hover → editable input. Save with Enter/blur, cancel with Escape.
- **Batch Delete**: "Manage" toggle → checkboxes → "Delete Selected (N)" button. Uses new bulk API endpoint.
- **Model Display**: Shows truncated model name in sidebar for sessions with saved model.
- **Resizable Sidebar**: Drag right edge to resize (200-500px). Width persisted to localStorage.

## Changes

| File | Changes |
|------|---------|
| `ChatPage.tsx` | Stop button, resize logic, handlers |
| `ChatHistorySidebar.tsx` | Model display, rename UI, selection mode |
| `api.ts` | `batchDeleteChatSessions()` client |
| `chat.ts` (server) | `POST /api/chats/batch/delete` endpoint |
| `queries.ts` | `deleteChatSessions()` bulk query |

## Test plan

- [ ] Start chat, click Stop mid-stream → stream halts
- [ ] Click pencil icon → edit title → Enter saves
- [ ] Press Escape while editing → cancels edit
- [ ] Click Manage → select chats → Delete Selected → all removed
- [ ] Resize sidebar by dragging right edge → width persists on reload
- [ ] Create chat with different model → model name shows in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-select and batch delete multiple chat sessions at once.
  * Inline editing for chat session titles with keyboard shortcuts (Enter to save, Escape to cancel).
  * Resizable sidebar that remembers your preferred width.
  * Stop button to cancel message generation during streaming responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->