### PR TITLE
feat: add Context7 MCP server preset

### DIFF
--- a/packages/shared/src/types/mcp.ts
+++ b/packages/shared/src/types/mcp.ts
@@ -192,4 +192,16 @@ export const MCP_SERVER_PRESETS: McpServerPreset[] = [
     },
     documentationUrl: 'https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem',
   },
+  {
+    name: 'context7',
+    displayName: 'Context7',
+    description: 'Up-to-date documentation for any library via Context7',
+    serverType: 'stdio',
+    config: {
+      command: 'npx',
+      args: ['-y', '@upstash/context7-mcp'],
+    },
+    apiKeyEnvVar: 'CONTEXT7_API_KEY',
+    documentationUrl: 'https://github.com/upstash/context7',
+  },
 ];


### PR DESCRIPTION
## Summary

- Add Context7 to MCP server quick-add presets
- Enables up-to-date library documentation lookup via Context7 API
- Uses `CONTEXT7_API_KEY` environment variable for authentication

## Configuration

- **Command:** `npx`
- **Args:** `-y`, `@upstash/context7-mcp`
- **API Key Env Var:** `CONTEXT7_API_KEY`
- **Documentation:** https://github.com/upstash/context7

## Test plan

- [ ] Add Context7 via Settings → MCP Servers → Quick Add
- [ ] Configure API key
- [ ] Test connection
- [ ] Verify tools are available in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Context7 MCP server preset enabling seamless access to up-to-date documentation for any library. This integration allows developers to reference the latest library documentation and API information directly within the application workflow. To use Context7, users will need to configure their API key through the application settings for proper authentication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->